### PR TITLE
CompCert 3.14

### DIFF
--- a/released/packages/coq-compcert/coq-compcert.3.14/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.14/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "The CompCert C compiler (64 bit)"
+maintainer: "Michael Soegtrop and Xavier Leroy"
+authors: "Xavier Leroy <xavier.leroy@college-de-france.fr>"
+license: "INRIA Non-Commercial License Agreement"
+tags: [
+  "category:Computer Science/Semantics and Compilation/Compilation"
+  "category:Computer Science/Semantics and Compilation/Semantics"
+  "keyword:C"
+  "keyword:compiler"
+  "logpath:compcert"
+  "date:2024-05-02"
+]
+homepage: "https://compcert.org/"
+bug-reports: "https://github.com/AbsInt/CompCert/issues"
+depends: [
+  "coq" {>= "8.12.0" & < "8.20~"}
+  "menhir" {>= "20190626" & != "dev"}
+  "ocaml" {>= "4.05.0" & < "5~"}
+  "coq-flocq" {>= "4.1.0" & < "5~"}
+  "coq-menhirlib" {>= "20190626"}
+]
+build: [
+  [
+    "./configure"
+    "amd64-linux" {os = "linux" & arch = "x86_64"}
+    "amd64-macosx" {os = "macos" & arch = "x86_64"}
+    "arm64-linux" {os = "linux" & (arch = "arm64" | arch = "aarch64")}
+    "arm64-macosx" {os = "macos" & (arch = "arm64" | arch = "aarch64")}
+    "amd64-cygwin" {os = "cygwin"}
+    "amd64-cygwin" {os = "win32" & os-distribution = "cygwinports"}
+    "-toolprefix"
+      {os = "win32" & os-distribution = "cygwinports" & arch = "i686"}
+    "x86_64-pc-cygwin-"
+      {os = "win32" & os-distribution = "cygwinports" & arch = "i686"}
+    "-prefix"
+    "%{prefix}%"
+    "-install-coqdev"
+    "-clightgen"
+    "-use-external-Flocq"
+    "-use-external-MenhirLib"
+    "-coqdevdir"
+    "%{lib}%/coq/user-contrib/compcert"
+    "-ignore-coq-version"
+  ]
+  [make "-j%{jobs}%" {ocaml:version >= "4.06"}]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/AbsInt/CompCert.git"
+url {
+  src: "https://github.com/AbsInt/CompCert/archive/v3.14.tar.gz"
+  checksum:
+    "sha512=cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+}

--- a/released/packages/coq-compcert/coq-compcert.3.14/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.14/opam
@@ -50,5 +50,5 @@ dev-repo: "git+https://github.com/AbsInt/CompCert.git"
 url {
   src: "https://github.com/AbsInt/CompCert/archive/v3.14.tar.gz"
   checksum:
-    "sha512=cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+    "sha512=5b3bdba47989f99340fc3e53e76c4994104cb884af123a09e867f5e66a3fc827e5290879a786dbdcda2fa5419210ffc151b5d6e9b4a459e29ca289fd5c12b19a"
 }


### PR DESCRIPTION
Released a few days ago.  See https://github.com/AbsInt/CompCert/releases/tag/v3.14 for a list of changes.
