### PR TITLE
CompCert version 3.15

### DIFF
--- a/released/packages/coq-compcert/coq-compcert.3.15/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.15/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "The CompCert C compiler (64 bit)"
+maintainer: "Michael Soegtrop and Xavier Leroy"
+authors: "Xavier Leroy <xavier.leroy@college-de-france.fr>"
+license: "INRIA Non-Commercial License Agreement"
+tags: [
+  "category:Computer Science/Semantics and Compilation/Compilation"
+  "category:Computer Science/Semantics and Compilation/Semantics"
+  "keyword:C"
+  "keyword:compiler"
+  "logpath:compcert"
+  "date:2024-12-13"
+]
+homepage: "https://compcert.org/"
+bug-reports: "https://github.com/AbsInt/CompCert/issues"
+depends: [
+  "coq" {>= "8.13.0" & < "8.21~"}
+  "menhir" {>= "20200624" & != "dev"}
+  "ocaml" {>= "4.05.0" & < "5~"}
+  "coq-flocq" {>= "4.1.0" & < "5~"}
+  "coq-menhirlib" {>= "20200624"}
+]
+build: [
+  [
+    "./configure"
+    "amd64-linux" {os = "linux" & arch = "x86_64"}
+    "amd64-macosx" {os = "macos" & arch = "x86_64"}
+    "arm64-linux" {os = "linux" & (arch = "arm64" | arch = "aarch64")}
+    "arm64-macosx" {os = "macos" & (arch = "arm64" | arch = "aarch64")}
+    "amd64-cygwin" {os = "cygwin"}
+    "amd64-cygwin" {os = "win32" & os-distribution = "cygwinports"}
+    "-toolprefix"
+      {os = "win32" & os-distribution = "cygwinports" & arch = "i686"}
+    "x86_64-pc-cygwin-"
+      {os = "win32" & os-distribution = "cygwinports" & arch = "i686"}
+    "-prefix"
+    "%{prefix}%"
+    "-install-coqdev"
+    "-clightgen"
+    "-use-external-Flocq"
+    "-use-external-MenhirLib"
+    "-coqdevdir"
+    "%{lib}%/coq/user-contrib/compcert"
+    "-ignore-coq-version"
+  ]
+  [make "-j%{jobs}%" {ocaml:version >= "4.06"}]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/AbsInt/CompCert.git"
+url {
+  src: "https://github.com/AbsInt/CompCert/archive/v3.15.tar.gz"
+  checksum: [
+    "sha256=6baae8f69bdbf0192d02fae911207cbde73bb1ff6b9790b1e745be0bd9b2342a"
+    "sha512=bde000d0da4ed5ba1c951a0d6677eb3f1386eb446cd85b59758145910bae2d002316396b12fdd0c11f31da8534fffa6a1dc74272ef6d2a96e245a7f44571c2dc"
+  ]
+}


### PR DESCRIPTION
## C language support

-  Minimal syntactic support for _Float16 type (half-precision FP numbers). Function declarations using _Float16 are correctly parsed, but any actual use of _Float16 is rejected later during compilation. (525)
-  Support C99 array declarator syntax involving static and *. These annotations are correctly parsed, but ignored during typing and compilation. (539)

## Code generation and optimization

-  Better support for _Bool type in the back-end and in the memory model.
-  This avoids redundant normalizations to _Bool.
-  Take types of function parameters into account during value analysis.
-  This avoids redundant normalizations on parameters of small integer types.
-  More conservative static analysis of pointer comparisons. (516)
-  Refined heuristic for if-conversion. Turn if-conversion off in some cases where it would prevent later optimization of conditional branches in the continuation of the if.
-  CSE: remember pointer alias information in Load equations, making it possible to remove more redundant memory loads. (518)
-  More precise value analysis of integer multiplication, division, modulus.
-  Constant propagation: optimize "known integer or undefined" results. For example, &x == &x, which is either 1 or undefined, is now replaced by 1.
-  Optimize (x ^ cst) != 0 into x != cst.
-  Avoid quadratic compile-time behavior on deeply-nested if statements. (519)

## Bug fixes

-  More robust determination of symbols that may be defined in a shared object. (538)
-  Escape $NNN identifiers in generated x86 and ARM assembly code (541).
-  Wrong parameter scoping in function definitions such as int (*f(int y))(int x) { ... } (a function returning a pointer to a prototyped function).

## Usability

-  Mark stack as non-executable in binaries produced by ccomp.
-  Check that preprocessed sources (.i files) do not contain backslash-newline sequences.
-  ./configure arm-linux now selects the hard-FP ABI, since Linux distributions no longer use the soft-FP ABI.

## Supporting libraries

-  ARM library for 64-bit integer arithmetic: faster division, cleaned-up code.

## Coq development

-  Support Coq 8.20.
-  Build: support TIMING and PROFILING like coq_makefile. (512)
-  Make dependency on Extraction explicit. (515)
-  Install .glob and .v files along .vo files. (527)
