### PR TITLE
Release rocq-vellvm v2.1.20250327

### DIFF
--- a/released/packages/rocq-vellvm/rocq-vellvm.v2.1.20250327/opam
+++ b/released/packages/rocq-vellvm/rocq-vellvm.v2.1.20250327/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer: "stevez@cis.upenn.edu"
+synopsis: "Rocq library implementing (executable) semantics for LLVM IR"
+
+homepage: "https://github.com/vellvm/vellvm"
+dev-repo: "git+https://github.com/vellvm/vellvm.git"
+bug-reports: "https://github.com/vellvm/vellvm/issues"
+authors: [
+  "Steve Zdancewic <stevez@cis.upenn.edu>"
+  "Yannick Zakowski <yannick.zakowski@inria.fr>"
+  "Calvin Beck <hobbes@seas.upenn.edu>"
+  "Irene Yoon <euisuny@cis.upenn.edu>"
+  "Gary (Hanxi) Chen <hanxic@seas.upenn.edu>"
+]
+license: "GPL-3.0-or-later"
+
+
+build: [make "-C" "src" "all" "-j%{jobs}%"]
+install: [make "-C" "src" "install"]
+
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "cppo"
+  "dune" {>= "3.14.0"}
+  "menhir"
+  "qcheck"
+  "rocq-core" {>= "9.0.0" & < "9.1~"}
+  "rocq-stdlib" {>= "9.0.0" & < "9.1~"}
+  "coq-ext-lib" {>= "0.13.0" & < "0.14~"}
+  "coq-paco"  {>= "4.2.3" & < "4.3~"}
+  "coq-ceres"
+  "coq-flocq" {>= "4.2.0"}
+  "coq-mathcomp-ssreflect"
+  "coq-simple-io"
+  "coq-itree" {>= "5.2.0" & < "5.3~"}
+  "coq-quickchick" {>= "2.0.4" & < "2.0.5"}
+]
+
+tags: [
+  "date:2025-03-27"
+
+  "category:Computer Science/Programming Languages/Formal Definitions and Theory"
+  "category:Computer Science/Semantics and Compilation/Compilation"
+  "category:Computer Science/Semantics and Compilation/Semantics"
+
+  "keyword:semantics"
+  "keyword:interpreter"
+  "keyword:LLVM"
+
+  "logpath:Vellvm"
+]
+
+url {
+  src: "https://github.com/vellvm/vellvm/releases/download/v2.1.20250327/v2.1.20250327.tar.gz"
+  checksum: "sha256=be1186cb5cc8ee405bbad841eb43326b0887ae92eca09f317133a34f163705a9"
+}


### PR DESCRIPTION
Updating vellvm to the following release:

https://github.com/vellvm/vellvm/releases/tag/v2.1.20250327

Notably this migrates to Rocq 9.0