### PR TITLE
renaming Coq to Rocq in all README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# opam archive for Coq
+# opam archive for the Rocq Prover and Coq
 
-All [opam](https://opam.ocaml.org) repositories for Coq packages live here.
-Packages are organized according to the [layout](https://coq.inria.fr/opam-layout.html):
+All [opam](https://opam.ocaml.org) repositories of packages for the [Rocq Prover](https://rocq-prover.org)
+and [Coq](https://rocq-prover.org/about#Name) live here. Packages are organized in repositories in the following way:
 
-* `released`: packages for officially released versions of Coq libraries and Coq extensions.
+* `released`: packages for officially released versions of libraries and extensions for the Rocq Prover and Coq.
 
-* `core-dev`: packages for development versions of Coq.
+* `core-dev`: packages for current and past development versions of the Rocq Prover and Coq.
 
-* `extra-dev`: packages for development versions of Coq libraries and Coq extensions.
+* `extra-dev`: packages for development versions of libraries and extensions for the Rocq Prover and Coq.
 
-We welcome pull requests to the `released` repository adding any Coq-related package that is compatible
-with a [released version of Coq](https://github.com/ocaml/opam-repository/tree/master/packages/coq).
-Besides _libraries_ of general interest, this also includes _paper artifacts_ and other
-_specialized formalizations_ that are not necessarily expected to be immediately reusable
-by others.
+We welcome pull requests to the `released` repository adding any Rocq or Coq-related package that is compatible
+with a [released version of the Rocq Prover](https://github.com/ocaml/opam-repository/tree/master/packages/rocq-prover)
+or a [released version of Coq](https://github.com/ocaml/opam-repository/tree/master/packages/coq).
+Besides _libraries_ and _extensions_ of general interest, this also includes _paper artifacts_ and
+other _specialized formalizations_ that are not necessarily expected to be immediately reusable by others.
 
 ## Usage
 
@@ -22,31 +22,31 @@ To activate the repositories:
 * `released` (recommended default):
 
     ```
-    opam repo add coq-released https://coq.inria.fr/opam/released
+    opam repo add rocq-released https://rocq-prover.org/opam/released
     ```
 
 * `core-dev`:
 
     ```
-    opam repo add coq-core-dev https://coq.inria.fr/opam/core-dev
+    opam repo add rocq-core-dev https://rocq-prover.org/opam/core-dev
     ```
 
 * `extra-dev`:
 
     ```
-    opam repo add coq-extra-dev https://coq.inria.fr/opam/extra-dev
+    opam repo add rocq-extra-dev https://rocq-prover.org/opam/extra-dev
     ```
 
 ## Adding packages
 
-See the [documentation](https://coq.inria.fr/opam-packaging.html) for how to add a package.
-You can also look at existing [pull requests](https://github.com/coq/opam-coq-archive/pulls)
+See the [general opam documentation](https://opam.ocaml.org/doc/Packaging.html) for how to prepare a package.
+You can also look at existing [pull requests](https://github.com/rocq-prover/opam/pulls)
 to see how others are adding packages.
 
-## Coq Platform
+## Rocq Platform
 
-The `released` opam archive is a key component of the [Coq Platform](https://github.com/coq/platform),
-a distribution of Coq together with a curated set of libraries and plugins.
+The `released` opam archive is a key component of the [Rocq Platform](https://github.com/rocq-prover/platform),
+a distribution of the Rocq Prover together with a curated set of libraries and plugins.
 After installing the Platform using scripts (as opposed to via a binary installer),
 additional packages in the `released` opam archive can be installed manually without the
 need for repository activation.
@@ -60,7 +60,7 @@ In particular, it uses the `tags` field of an `opam` file as follows:
 
  1. strings beginning with `keyword:` are considered as `keywords`
  2. strings beginning with `category:` are considered as `categories`
- 3. a string beginning with `logpath:` is considered the Coq logical path prefix
+ 3. a string beginning with `logpath:` is considered the Rocq logical path prefix
  4. a string beginning with `date:` is the date the software was last updated
     (not the package definition)
 
@@ -80,21 +80,21 @@ The `homepage:`, `author:`, `maintainer:`, and `doc:` fields are
 also used to generate the package entry.
 
 The JSON file is generated during continuous integration and
-[copied to the website](https://coq.inria.fr/opam/coq-packages.json).
+[copied to the website](https://rocq-prover.org/opam/coq-packages.json).
 JavaScript code on the website then loads it to dynamically generate
 the content of the website on the client side.
 
-See also [CEP3](https://github.com/coq/ceps/blob/master/text/003-opam-metadata.md) and
-the [deployed website](https://coq.inria.fr/opam/www/).
+See also [RFC#3](https://github.com/rocq-prover/rfcs/blob/master/text/003-opam-metadata.md) and
+the [Rocq package index](https://rocq-prover.org/packages).
 
 ## Continuous integration
 
 Incoming pull requests are tested on GitLab CI. **@coqbot** pushes any opened
 or synchonized pull request to a branch named `pr-<number>` on GitLab. It will
 trigger a CI build. If the CI build runs for too long and times out, any
-member of the Coq organization of GitLab can start it again using the "Run
-Pipeline" green button at <https://gitlab.com/coq/opam-coq-archive/pipelines>.
-This will then build only on runners without pre-set timeouts (the Coq Pyrolyse
+member of the Rocq organization of GitLab can start it again using the "Run
+Pipeline" green button at <https://gitlab.inria.fr/coq/opam/-/pipelines>.
+This will then build only on runners without pre-set timeouts (the Rocq Pyrolyse
 server). It may still time out if the build takes longer than the GitLab
 project's timeout setting (24 hours). To skip some packages the first PR
 message can contain a line such as `ci-skip: p1.v1 p2 p3.v3 p4` where

--- a/core-dev/README.md
+++ b/core-dev/README.md
@@ -1,6 +1,9 @@
 # Core-Dev repository
-The repository for the development versions of Coq. Use it at your own risks.
 
-    opam repo add coq-core-dev https://coq.inria.fr/opam/core-dev
+The repository for development versions of the Rocq Prover and Coq. Use it at your own risk.
 
-If you want to add your Coq version, please do a pull-request to this repository.
+    ```
+    opam repo add rocq-core-dev https://rocq-prover.org/opam/core-dev
+    ```
+
+If you want to add your Rocq Prover version, please do a pull-request to this repository.

--- a/core-dev/repo
+++ b/core-dev/repo
@@ -1,2 +1,3 @@
 opam-version: "2.0"
-upstream: "https://github.com/coq/opam-coq-archive/tree/master"
+browse: "https://rocq-prover.org/packages"
+upstream: "https://github.com/rocq-prover/opam/tree/master/core-dev"

--- a/extra-dev/README.md
+++ b/extra-dev/README.md
@@ -1,7 +1,10 @@
 # Extra-Dev repository
-The repository for the development packages. Use it at your own risks.
 
-    opam repo add coq-released https://coq.inria.fr/opam/released
-    opam repo add coq-extra-dev https://coq.inria.fr/opam/extra-dev
+The repository for development packages. Use it at your own risk.
 
-If you want to add your package, please do a pull-request to this repository.
+    ```
+    opam repo add rocq-released https://rocq-prover.org/opam/released
+    opam repo add rocq-extra-dev https://rocq-prover.org/opam/extra-dev
+    ```
+
+If you want to add your package, please do a pull request to this repository.

--- a/extra-dev/repo
+++ b/extra-dev/repo
@@ -1,3 +1,3 @@
 opam-version: "2.0"
-browse: "https://coq.inria.fr/opam/www/"
-upstream: "https://github.com/coq/opam-coq-archive/tree/master"
+browse: "https://rocq-prover.org/packages"
+upstream: "https://github.com/rocq-prover/opam/tree/master/extra-dev"

--- a/released/README.md
+++ b/released/README.md
@@ -1,6 +1,9 @@
 # Released repository
-The repository for all the released packages.
 
-    opam repo add coq-released https://coq.inria.fr/opam/released
+The repository for all released packages. This is the recommended default.
 
-If you want to add your package, please do a pull-request to this repository.
+    ```
+    opam repo add rocq-released https://rocq-prover.org/opam/released
+    ```
+
+If you want to add your package, please do a pull request to this repository.

--- a/released/repo
+++ b/released/repo
@@ -1,6 +1,3 @@
 opam-version: "2.0"
-browse: "https://coq.inria.fr/opam/www/"
-upstream: "https://github.com/coq/opam-coq-archive/tree/master"
-redirect:
-  "https://coq.github.io/opam-coq-archive/released-opam1.2"
-    {opam-version < "2.0~"}
+browse: "https://rocq-prover.org/packages"
+upstream: "https://github.com/rocq-prover/opam/tree/master/released"


### PR DESCRIPTION
Due to https://github.com/rocq-prover/rocq-prover.org/issues/9 we can't link to Rocq opam archive specific instructions.