### PR TITLE
Fix hashes of metacoq releases

### DIFF
--- a/released/packages/coq-metacoq-common/coq-metacoq-common.1.2+8.16/opam
+++ b/released/packages/coq-metacoq-common/coq-metacoq-common.1.2+8.16/opam
@@ -35,5 +35,5 @@ MetaCoq is a meta-programming framework for Coq.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2-8.16/metacoq-1.2-8.16.tar.gz"
-  checksum: "sha512=80739c1424f5c28afadfcc581fa7016bc26f28f3a8b79597abc52ba5cc404cbe3728cccb260ab5ff7ed71ecb9a66690bcaa8d9cc6c0b79d2d1b5e660c34d5008"
+  checksum: "sha512=ff42d9391a01c2cd37f98766cb430c2740161f3dc34c7588e471476b05293b5eb7d4e392c3b42e9f24604edfe251d403516047188012beca90d8f3601898d6af"
 }

--- a/released/packages/coq-metacoq-common/coq-metacoq-common.1.2+8.17/opam
+++ b/released/packages/coq-metacoq-common/coq-metacoq-common.1.2+8.17/opam
@@ -35,5 +35,5 @@ MetaCoq is a meta-programming framework for Coq.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2-8.17/metacoq-1.2-8.17.tar.gz"
-  checksum: "sha512=ef36dfe0e7864c67e223484f400f38531b41059c6e6e206a329b4dfa2c29e36ee133a711656fec3edcb37b046e5602d1a81c9989c399729f4547f19e854ccdbd"
+  checksum: "sha512=17add66108aadc1f8d9d513c92c94e94265cd10ad73d7999dd0ee2e53666094af7ec8aa9d93f089389576f2efc5fb4b23faad663319f814fbbc73aaf8e2bf999"
 }

--- a/released/packages/coq-metacoq-common/coq-metacoq-common.1.2.1+8.17/opam
+++ b/released/packages/coq-metacoq-common/coq-metacoq-common.1.2.1+8.17/opam
@@ -35,5 +35,5 @@ MetaCoq is a meta-programming framework for Coq.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2.1-8.17/metacoq-1.2.1-8.17.tar.gz"
-  checksum: "sha512=c02f106aafa1082bb6c2be5bb1c972840cd23d94c85541996767855e1a3080bc00405f463d275285847385680aa69b3798d067ed73e4712d8a137024cc256cab"
+  checksum: "sha512=c19536c0907711c28287844dcc469cb61ebda02c154c62174419b41fffc72ea58f8ac5a84711c6273b68b1d01f20741cc5c762501eddb8a1185befb6c4d15294"
 }

--- a/released/packages/coq-metacoq-common/coq-metacoq-common.1.2.1+8.18/opam
+++ b/released/packages/coq-metacoq-common/coq-metacoq-common.1.2.1+8.18/opam
@@ -35,5 +35,5 @@ MetaCoq is a meta-programming framework for Coq.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2.1-8.18/metacoq-1.2.1-8.18.tar.gz"
-  checksum: "sha512=3b2a6c1cb8005a7f675c47209b17f0b3f2ded6b3ae324f6a6782f0b23e5e5e5e25ac1d1c8a97be1c9b89b4490dda80567a3f57c254314a185a01ca9f0fc94d82"
+  checksum: "sha512=0ad6a8777807d744ceb330e05989880422f6e2afa462571bff4e2d97b55ed7a0987998192e4ce289472b81112731bfdba0379b52e810fbe0851cc61a0e29b29e"
 }

--- a/released/packages/coq-metacoq-common/coq-metacoq-common.1.3+8.17/opam
+++ b/released/packages/coq-metacoq-common/coq-metacoq-common.1.3+8.17/opam
@@ -35,5 +35,5 @@ MetaCoq is a meta-programming framework for Coq.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.3-8.17/metacoq-1.3-8.17.tar.gz"
-  checksum: "sha512=eef100ec9a30031d99e8f626f00fbd4d3156bc64e440086876c13490207e6fd845cf9c0688dc417feb4f4acd1c9ca7f3d467dd3250319090250c926e7c62fba0"
+  checksum: "sha512=ff4ed8a4cf33afb2a93c8ec07f00327f9924e82c81cb82ca74e0fe81b2199d5b13716fe5224fc0998952936c59ff0f52ed79703641745114a2ac777ab86beeb4"
 }

--- a/released/packages/coq-metacoq-common/coq-metacoq-common.1.3.4+8.20/opam
+++ b/released/packages/coq-metacoq-common/coq-metacoq-common.1.3.4+8.20/opam
@@ -34,6 +34,6 @@ description: """
 MetaCoq is a meta-programming framework for Coq.
 """
 url {
-  src: "https://github.com/MetaCoq/metacoq/archive/refs/tags/v1.3.4-8.20.tar.gz"
-  checksum: "sha512=fb3997e2e07e9c33c293aabcc06b8e69785a9c2ebdcd4d48f77e1eb09698da6ed1770127022843f89322cf8f78289acd67c860e1a2d9186d5703191ccd088429"
+  src: "https://github.com/MetaRocq/metarocq/releases/download/v1.3.4-8.20/metacoq-1.3.4-8.20.tar.gz"
+  checksum: "sha512=82d2a0cf514dce221557a3f63d024a1a020a8a6b20de7e859d1df3f58266ae432122545602a5a382ba4c21161e976c4cc0aa0b2601ee5a838b287883ebabc75a"
 }

--- a/released/packages/coq-metacoq-erasure-plugin/coq-metacoq-erasure-plugin.1.2+8.16/opam
+++ b/released/packages/coq-metacoq-erasure-plugin/coq-metacoq-erasure-plugin.1.2+8.16/opam
@@ -44,5 +44,5 @@ thesis.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2-8.16/metacoq-1.2-8.16.tar.gz"
-  checksum: "sha512=80739c1424f5c28afadfcc581fa7016bc26f28f3a8b79597abc52ba5cc404cbe3728cccb260ab5ff7ed71ecb9a66690bcaa8d9cc6c0b79d2d1b5e660c34d5008"
+  checksum: "sha512=ff42d9391a01c2cd37f98766cb430c2740161f3dc34c7588e471476b05293b5eb7d4e392c3b42e9f24604edfe251d403516047188012beca90d8f3601898d6af"
 }

--- a/released/packages/coq-metacoq-erasure-plugin/coq-metacoq-erasure-plugin.1.2+8.17/opam
+++ b/released/packages/coq-metacoq-erasure-plugin/coq-metacoq-erasure-plugin.1.2+8.17/opam
@@ -44,5 +44,5 @@ thesis.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2-8.17/metacoq-1.2-8.17.tar.gz"
-  checksum: "sha512=ef36dfe0e7864c67e223484f400f38531b41059c6e6e206a329b4dfa2c29e36ee133a711656fec3edcb37b046e5602d1a81c9989c399729f4547f19e854ccdbd"
+  checksum: "sha512=17add66108aadc1f8d9d513c92c94e94265cd10ad73d7999dd0ee2e53666094af7ec8aa9d93f089389576f2efc5fb4b23faad663319f814fbbc73aaf8e2bf999"
 }

--- a/released/packages/coq-metacoq-erasure-plugin/coq-metacoq-erasure-plugin.1.2.1+8.17/opam
+++ b/released/packages/coq-metacoq-erasure-plugin/coq-metacoq-erasure-plugin.1.2.1+8.17/opam
@@ -44,5 +44,5 @@ thesis.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2.1-8.17/metacoq-1.2.1-8.17.tar.gz"
-  checksum: "sha512=c02f106aafa1082bb6c2be5bb1c972840cd23d94c85541996767855e1a3080bc00405f463d275285847385680aa69b3798d067ed73e4712d8a137024cc256cab"
+  checksum: "sha512=c19536c0907711c28287844dcc469cb61ebda02c154c62174419b41fffc72ea58f8ac5a84711c6273b68b1d01f20741cc5c762501eddb8a1185befb6c4d15294"
 }

--- a/released/packages/coq-metacoq-erasure-plugin/coq-metacoq-erasure-plugin.1.2.1+8.18/opam
+++ b/released/packages/coq-metacoq-erasure-plugin/coq-metacoq-erasure-plugin.1.2.1+8.18/opam
@@ -44,5 +44,5 @@ thesis.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2.1-8.18/metacoq-1.2.1-8.18.tar.gz"
-  checksum: "sha512=3b2a6c1cb8005a7f675c47209b17f0b3f2ded6b3ae324f6a6782f0b23e5e5e5e25ac1d1c8a97be1c9b89b4490dda80567a3f57c254314a185a01ca9f0fc94d82"
+  checksum: "sha512=0ad6a8777807d744ceb330e05989880422f6e2afa462571bff4e2d97b55ed7a0987998192e4ce289472b81112731bfdba0379b52e810fbe0851cc61a0e29b29e"
 }

--- a/released/packages/coq-metacoq-erasure-plugin/coq-metacoq-erasure-plugin.1.3+8.17/opam
+++ b/released/packages/coq-metacoq-erasure-plugin/coq-metacoq-erasure-plugin.1.3+8.17/opam
@@ -44,5 +44,5 @@ thesis.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.3-8.17/metacoq-1.3-8.17.tar.gz"
-  checksum: "sha512=eef100ec9a30031d99e8f626f00fbd4d3156bc64e440086876c13490207e6fd845cf9c0688dc417feb4f4acd1c9ca7f3d467dd3250319090250c926e7c62fba0"
+  checksum: "sha512=ff4ed8a4cf33afb2a93c8ec07f00327f9924e82c81cb82ca74e0fe81b2199d5b13716fe5224fc0998952936c59ff0f52ed79703641745114a2ac777ab86beeb4"
 }

--- a/released/packages/coq-metacoq-erasure-plugin/coq-metacoq-erasure-plugin.1.3.4+8.20/opam
+++ b/released/packages/coq-metacoq-erasure-plugin/coq-metacoq-erasure-plugin.1.3.4+8.20/opam
@@ -43,6 +43,6 @@ into a dummy `tBox` constructor, following closely P. Letouzey's PhD
 thesis.
 """
 url {
-  src: "https://github.com/MetaCoq/metacoq/archive/refs/tags/v1.3.4-8.20.tar.gz"
-  checksum: "sha512=fb3997e2e07e9c33c293aabcc06b8e69785a9c2ebdcd4d48f77e1eb09698da6ed1770127022843f89322cf8f78289acd67c860e1a2d9186d5703191ccd088429"
+  src: "https://github.com/MetaRocq/metarocq/releases/download/v1.3.4-8.20/metacoq-1.3.4-8.20.tar.gz"
+  checksum: "sha512=82d2a0cf514dce221557a3f63d024a1a020a8a6b20de7e859d1df3f58266ae432122545602a5a382ba4c21161e976c4cc0aa0b2601ee5a838b287883ebabc75a"
 }

--- a/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.0+8.14/opam
+++ b/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.0+8.14/opam
@@ -44,5 +44,5 @@ thesis.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.0-8.14/metacoq-1.0-8.14.tar.gz"
-  checksum: "sha512=208a6ba9ca2f2e4b9968baca059e5c290d22d083c30591c53b70275b82478510327c27cd6980ddae6245e491a976ffcbbfa4d004767e6dc172a88f042f921698"
+  checksum: "sha512=7271ce4158054dc2b349e0642d714865ab63cc6a6fe054a19fa47d2b93441a1f59c7f60642917e8fce2a5ec998d9437a3959316a33ab6695fcaf052bc50d6ffd"
 }

--- a/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.0+8.15/opam
+++ b/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.0+8.15/opam
@@ -44,5 +44,5 @@ thesis.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.0-8.15/metacoq-1.0-8.15.tar.gz"
-  checksum: "sha512=8bf61d638afcefa661f65a3e7384fdffef358bed4985a9df8d60dc200603172d1931ad94cbc028e82ba9b44778f59428e240e02642111765a4470a1202264224"
+  checksum: "sha512=4747d378d91bef1b248f137be6851a5acddb34968d913daeda923ca6a3a009c3dcccdcf497c33d94f113636e469ef5046e71a23115dc22ea2e6069b7de72f5fc"
 }

--- a/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.0+8.16/opam
+++ b/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.0+8.16/opam
@@ -43,5 +43,5 @@ thesis.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.0-8.16/metacoq-1.0-8.16.tar.gz"
-  checksum: "sha512=44f9364cfb0a2995e0adadbdb181e53a1dccd98781ab1b9abdde7942ee4b15ea233bca97c28e3185c8492a8af7db7cfe57e34d535b94d5465b9f3c3c5eb3f4e7"
+  checksum: "sha512=7e36b16d5de8952c92046971c0bc57f80da3a4d88f39aa6cdfa13756c19513738374f2ab725c2bce7ceb87402e3026a76c79d2ee4dfcdd3fc4ffc8cd4f1f00c8"
 }

--- a/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.1+8.14/opam
+++ b/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.1+8.14/opam
@@ -44,5 +44,5 @@ thesis.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1-8.14/metacoq-1.1-8.14.tar.gz"
-  checksum: "sha512=e5cc8a540c7a7bb2a783c41ed6f6808362bf27c781fbb1f609e2b8da881065eba7adb74cf99132aa40329f88fec7547e79a6fdef268e609604cf35e82dc7ee6a"
+  checksum: "sha512=48edab0cfa08c45e2c691d2c01abce1b97a0d15d2d957e90ca8f08dbc0f20d7d8019fb4fb85cf968439cb991f3297e9c2abf0a113a518a2a46fa54814a7d4aea"
 }

--- a/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.1+8.15/opam
+++ b/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.1+8.15/opam
@@ -44,5 +44,5 @@ thesis.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1-8.15/metacoq-1.1-8.15.tar.gz"
-  checksum: "sha512=ebb88e267033fc6167f41d51ccb233c171eb70775ba3b04aa3c7517ff073be31dcdf331e9901897d6c3e5893f6d12ec48d5851d44c23b1ec8c7e7d3d505eb360"
+  checksum: "sha512=12ea0aff460c7eee07b5341ebcbf231c0f8aed9346842ad53c2244ab5ed865a0ecf6764116fbb26ecd3558f3de29c6054b8769d0c084b6d291a6b0e9a751c69a"
 }

--- a/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.1+8.16/opam
+++ b/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.1+8.16/opam
@@ -44,5 +44,5 @@ thesis.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1-8.16/metacoq-1.1-8.16.tar.gz"
-  checksum: "sha512=aa984b616d5e91a264e765973ef02d8c180da282d7c87017fc2ca7f783ed819f0f62f5f96c1cab7f11fc2993cbb424f48c4a00a0bcdf0c98f19460cd7dcce5aa"
+  checksum: "sha512=89e9c6a2aaaf0512d981c1e2272bafc0a20a226a1e8834bf67a1054906f28aa1ce343da725e5e74e929d83c8685cd5222c879d6e6eb19124b26d3a3aea70d811"
 }

--- a/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.1.1+8.14/opam
+++ b/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.1.1+8.14/opam
@@ -44,5 +44,5 @@ thesis.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1.1-8.14/metacoq-1.1.1-8.14.tar.gz"
-  checksum: "sha512=e54a9dc6a01dbe7c95343327e63eed8011366347bd02c29eca9426a6b8d955e5d0209df448e2f2fbb517e8b928f7d22276e55aae092bd3c4e9f4ba11bcac85c5"
+  checksum: "sha512=f9918b1cbe14b63350fad399ec8201c76c4e7af9082a39928f54285978ba21eba0e89a5e18f1a20fc867e41d80416863402a4de972b30aaf2627548fb27d4268"
 }

--- a/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.1.1+8.15/opam
+++ b/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.1.1+8.15/opam
@@ -44,5 +44,5 @@ thesis.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1.1-8.15/metacoq-1.1.1-8.15.tar.gz"
-  checksum: "sha512=651f6f59cae604169a8c2fef48df75324791adf1becd881b36f01c5bc407a6fef9209d69f4c917d72e8c86f06ae2db976cfed6778be438786b14ab6daf771c25"
+  checksum: "sha512=05372e6e0d82fb7dd0bc2f3088aa6828b54f4c835526d52514f1d71d5d49b79a4506844de4a539bc951d7eb71f268e1f753a832e4ae4669f871c3b2323357ca0"
 }

--- a/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.1.1+8.16/opam
+++ b/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.1.1+8.16/opam
@@ -44,5 +44,5 @@ thesis.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1.1-8.16/metacoq-1.1.1-8.16.tar.gz"
-  checksum: "sha512=babae48068b31833a695ddbf7cac1043ccab778dcb5ea1cd6db3277f77f994a926636b10e58254615c88d080f69fc1885ea11d5bc8743e313e621aab2c9e48db"
+  checksum: "sha512=778e5cc64d35b782559fb245853444b2f87b4b3580acc62921251f8dfebf11e2be81ad1f37bdc26421faf7fc2678478028c097cc0afa61e5574b3072d5288917"
 }

--- a/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.2+8.16/opam
+++ b/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.2+8.16/opam
@@ -44,5 +44,5 @@ thesis.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2-8.16/metacoq-1.2-8.16.tar.gz"
-  checksum: "sha512=80739c1424f5c28afadfcc581fa7016bc26f28f3a8b79597abc52ba5cc404cbe3728cccb260ab5ff7ed71ecb9a66690bcaa8d9cc6c0b79d2d1b5e660c34d5008"
+  checksum: "sha512=ff42d9391a01c2cd37f98766cb430c2740161f3dc34c7588e471476b05293b5eb7d4e392c3b42e9f24604edfe251d403516047188012beca90d8f3601898d6af"
 }

--- a/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.2+8.17/opam
+++ b/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.2+8.17/opam
@@ -44,5 +44,5 @@ thesis.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2-8.17/metacoq-1.2-8.17.tar.gz"
-  checksum: "sha512=ef36dfe0e7864c67e223484f400f38531b41059c6e6e206a329b4dfa2c29e36ee133a711656fec3edcb37b046e5602d1a81c9989c399729f4547f19e854ccdbd"
+  checksum: "sha512=17add66108aadc1f8d9d513c92c94e94265cd10ad73d7999dd0ee2e53666094af7ec8aa9d93f089389576f2efc5fb4b23faad663319f814fbbc73aaf8e2bf999"
 }

--- a/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.2.1+8.17/opam
+++ b/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.2.1+8.17/opam
@@ -44,5 +44,5 @@ thesis.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2.1-8.17/metacoq-1.2.1-8.17.tar.gz"
-  checksum: "sha512=c02f106aafa1082bb6c2be5bb1c972840cd23d94c85541996767855e1a3080bc00405f463d275285847385680aa69b3798d067ed73e4712d8a137024cc256cab"
+  checksum: "sha512=c19536c0907711c28287844dcc469cb61ebda02c154c62174419b41fffc72ea58f8ac5a84711c6273b68b1d01f20741cc5c762501eddb8a1185befb6c4d15294"
 }

--- a/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.2.1+8.18/opam
+++ b/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.2.1+8.18/opam
@@ -44,5 +44,5 @@ thesis.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2.1-8.18/metacoq-1.2.1-8.18.tar.gz"
-  checksum: "sha512=3b2a6c1cb8005a7f675c47209b17f0b3f2ded6b3ae324f6a6782f0b23e5e5e5e25ac1d1c8a97be1c9b89b4490dda80567a3f57c254314a185a01ca9f0fc94d82"
+  checksum: "sha512=0ad6a8777807d744ceb330e05989880422f6e2afa462571bff4e2d97b55ed7a0987998192e4ce289472b81112731bfdba0379b52e810fbe0851cc61a0e29b29e"
 }

--- a/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.3+8.17/opam
+++ b/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.3+8.17/opam
@@ -44,5 +44,5 @@ thesis.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.3-8.17/metacoq-1.3-8.17.tar.gz"
-  checksum: "sha512=eef100ec9a30031d99e8f626f00fbd4d3156bc64e440086876c13490207e6fd845cf9c0688dc417feb4f4acd1c9ca7f3d467dd3250319090250c926e7c62fba0"
+  checksum: "sha512=ff4ed8a4cf33afb2a93c8ec07f00327f9924e82c81cb82ca74e0fe81b2199d5b13716fe5224fc0998952936c59ff0f52ed79703641745114a2ac777ab86beeb4"
 }

--- a/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.3.4+8.20/opam
+++ b/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.3.4+8.20/opam
@@ -43,6 +43,6 @@ into a dummy `tBox` constructor, following closely P. Letouzey's PhD
 thesis.
 """
 url {
-  src: "https://github.com/MetaCoq/metacoq/archive/refs/tags/v1.3.4-8.20.tar.gz"
-  checksum: "sha512=fb3997e2e07e9c33c293aabcc06b8e69785a9c2ebdcd4d48f77e1eb09698da6ed1770127022843f89322cf8f78289acd67c860e1a2d9186d5703191ccd088429"
+  src: "https://github.com/MetaRocq/metarocq/releases/download/v1.3.4-8.20/metacoq-1.3.4-8.20.tar.gz"
+  checksum: "sha512=82d2a0cf514dce221557a3f63d024a1a020a8a6b20de7e859d1df3f58266ae432122545602a5a382ba4c21161e976c4cc0aa0b2601ee5a838b287883ebabc75a"
 }

--- a/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.0+8.14/opam
+++ b/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.0+8.14/opam
@@ -39,5 +39,5 @@ PCUIC: Weakening, Substitution, Confluence and Subject Reduction are proven here
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.0-8.14/metacoq-1.0-8.14.tar.gz"
-  checksum: "sha512=208a6ba9ca2f2e4b9968baca059e5c290d22d083c30591c53b70275b82478510327c27cd6980ddae6245e491a976ffcbbfa4d004767e6dc172a88f042f921698"
+  checksum: "sha512=7271ce4158054dc2b349e0642d714865ab63cc6a6fe054a19fa47d2b93441a1f59c7f60642917e8fce2a5ec998d9437a3959316a33ab6695fcaf052bc50d6ffd"
 }

--- a/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.0+8.15/opam
+++ b/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.0+8.15/opam
@@ -38,5 +38,5 @@ PCUIC: Weakening, Substitution, Confluence and Subject Reduction are proven here
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.0-8.15/metacoq-1.0-8.15.tar.gz"
-  checksum: "sha512=8bf61d638afcefa661f65a3e7384fdffef358bed4985a9df8d60dc200603172d1931ad94cbc028e82ba9b44778f59428e240e02642111765a4470a1202264224"
+  checksum: "sha512=4747d378d91bef1b248f137be6851a5acddb34968d913daeda923ca6a3a009c3dcccdcf497c33d94f113636e469ef5046e71a23115dc22ea2e6069b7de72f5fc"
 }

--- a/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.0+8.16/opam
+++ b/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.0+8.16/opam
@@ -37,5 +37,5 @@ PCUIC: Weakening, Substitution, Confluence and Subject Reduction are proven here
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.0-8.16/metacoq-1.0-8.16.tar.gz"
-  checksum: "sha512=44f9364cfb0a2995e0adadbdb181e53a1dccd98781ab1b9abdde7942ee4b15ea233bca97c28e3185c8492a8af7db7cfe57e34d535b94d5465b9f3c3c5eb3f4e7"
+  checksum: "sha512=7e36b16d5de8952c92046971c0bc57f80da3a4d88f39aa6cdfa13756c19513738374f2ab725c2bce7ceb87402e3026a76c79d2ee4dfcdd3fc4ffc8cd4f1f00c8"
 }

--- a/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.1+8.14/opam
+++ b/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.1+8.14/opam
@@ -39,5 +39,5 @@ PCUIC: Weakening, Substitution, Confluence and Subject Reduction are proven here
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1-8.14/metacoq-1.1-8.14.tar.gz"
-  checksum: "sha512=e5cc8a540c7a7bb2a783c41ed6f6808362bf27c781fbb1f609e2b8da881065eba7adb74cf99132aa40329f88fec7547e79a6fdef268e609604cf35e82dc7ee6a"
+  checksum: "sha512=48edab0cfa08c45e2c691d2c01abce1b97a0d15d2d957e90ca8f08dbc0f20d7d8019fb4fb85cf968439cb991f3297e9c2abf0a113a518a2a46fa54814a7d4aea"
 }

--- a/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.1+8.15/opam
+++ b/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.1+8.15/opam
@@ -38,5 +38,5 @@ PCUIC: Weakening, Substitution, Confluence and Subject Reduction are proven here
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1-8.15/metacoq-1.1-8.15.tar.gz"
-  checksum: "sha512=ebb88e267033fc6167f41d51ccb233c171eb70775ba3b04aa3c7517ff073be31dcdf331e9901897d6c3e5893f6d12ec48d5851d44c23b1ec8c7e7d3d505eb360"
+  checksum: "sha512=12ea0aff460c7eee07b5341ebcbf231c0f8aed9346842ad53c2244ab5ed865a0ecf6764116fbb26ecd3558f3de29c6054b8769d0c084b6d291a6b0e9a751c69a"
 }

--- a/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.1+8.16/opam
+++ b/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.1+8.16/opam
@@ -38,5 +38,5 @@ PCUIC: Weakening, Substitution, Confluence and Subject Reduction are proven here
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1-8.16/metacoq-1.1-8.16.tar.gz"
-  checksum: "sha512=aa984b616d5e91a264e765973ef02d8c180da282d7c87017fc2ca7f783ed819f0f62f5f96c1cab7f11fc2993cbb424f48c4a00a0bcdf0c98f19460cd7dcce5aa"
+  checksum: "sha512=89e9c6a2aaaf0512d981c1e2272bafc0a20a226a1e8834bf67a1054906f28aa1ce343da725e5e74e929d83c8685cd5222c879d6e6eb19124b26d3a3aea70d811"
 }

--- a/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.1.1+8.14/opam
+++ b/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.1.1+8.14/opam
@@ -39,5 +39,5 @@ PCUIC: Weakening, Substitution, Confluence and Subject Reduction are proven here
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1.1-8.14/metacoq-1.1.1-8.14.tar.gz"
-  checksum: "sha512=e54a9dc6a01dbe7c95343327e63eed8011366347bd02c29eca9426a6b8d955e5d0209df448e2f2fbb517e8b928f7d22276e55aae092bd3c4e9f4ba11bcac85c5"
+  checksum: "sha512=f9918b1cbe14b63350fad399ec8201c76c4e7af9082a39928f54285978ba21eba0e89a5e18f1a20fc867e41d80416863402a4de972b30aaf2627548fb27d4268"
 }

--- a/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.1.1+8.15/opam
+++ b/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.1.1+8.15/opam
@@ -38,5 +38,5 @@ PCUIC: Weakening, Substitution, Confluence and Subject Reduction are proven here
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1.1-8.15/metacoq-1.1.1-8.15.tar.gz"
-  checksum: "sha512=651f6f59cae604169a8c2fef48df75324791adf1becd881b36f01c5bc407a6fef9209d69f4c917d72e8c86f06ae2db976cfed6778be438786b14ab6daf771c25"
+  checksum: "sha512=05372e6e0d82fb7dd0bc2f3088aa6828b54f4c835526d52514f1d71d5d49b79a4506844de4a539bc951d7eb71f268e1f753a832e4ae4669f871c3b2323357ca0"
 }

--- a/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.1.1+8.16/opam
+++ b/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.1.1+8.16/opam
@@ -38,5 +38,5 @@ PCUIC: Weakening, Substitution, Confluence and Subject Reduction are proven here
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1.1-8.16/metacoq-1.1.1-8.16.tar.gz"
-  checksum: "sha512=babae48068b31833a695ddbf7cac1043ccab778dcb5ea1cd6db3277f77f994a926636b10e58254615c88d080f69fc1885ea11d5bc8743e313e621aab2c9e48db"
+  checksum: "sha512=778e5cc64d35b782559fb245853444b2f87b4b3580acc62921251f8dfebf11e2be81ad1f37bdc26421faf7fc2678478028c097cc0afa61e5574b3072d5288917"
 }

--- a/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.2+8.16/opam
+++ b/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.2+8.16/opam
@@ -39,5 +39,5 @@ PCUIC: Weakening, Substitution, Confluence and Subject Reduction are proven here
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2-8.16/metacoq-1.2-8.16.tar.gz"
-  checksum: "sha512=80739c1424f5c28afadfcc581fa7016bc26f28f3a8b79597abc52ba5cc404cbe3728cccb260ab5ff7ed71ecb9a66690bcaa8d9cc6c0b79d2d1b5e660c34d5008"
+  checksum: "sha512=ff42d9391a01c2cd37f98766cb430c2740161f3dc34c7588e471476b05293b5eb7d4e392c3b42e9f24604edfe251d403516047188012beca90d8f3601898d6af"
 }

--- a/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.2+8.17/opam
+++ b/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.2+8.17/opam
@@ -39,5 +39,5 @@ PCUIC: Weakening, Substitution, Confluence and Subject Reduction are proven here
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2-8.17/metacoq-1.2-8.17.tar.gz"
-  checksum: "sha512=ef36dfe0e7864c67e223484f400f38531b41059c6e6e206a329b4dfa2c29e36ee133a711656fec3edcb37b046e5602d1a81c9989c399729f4547f19e854ccdbd"
+  checksum: "sha512=17add66108aadc1f8d9d513c92c94e94265cd10ad73d7999dd0ee2e53666094af7ec8aa9d93f089389576f2efc5fb4b23faad663319f814fbbc73aaf8e2bf999"
 }

--- a/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.2.1+8.17/opam
+++ b/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.2.1+8.17/opam
@@ -39,5 +39,5 @@ PCUIC: Weakening, Substitution, Confluence and Subject Reduction are proven here
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2.1-8.17/metacoq-1.2.1-8.17.tar.gz"
-  checksum: "sha512=c02f106aafa1082bb6c2be5bb1c972840cd23d94c85541996767855e1a3080bc00405f463d275285847385680aa69b3798d067ed73e4712d8a137024cc256cab"
+  checksum: "sha512=c19536c0907711c28287844dcc469cb61ebda02c154c62174419b41fffc72ea58f8ac5a84711c6273b68b1d01f20741cc5c762501eddb8a1185befb6c4d15294"
 }

--- a/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.2.1+8.18/opam
+++ b/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.2.1+8.18/opam
@@ -39,5 +39,5 @@ PCUIC: Weakening, Substitution, Confluence and Subject Reduction are proven here
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2.1-8.18/metacoq-1.2.1-8.18.tar.gz"
-  checksum: "sha512=3b2a6c1cb8005a7f675c47209b17f0b3f2ded6b3ae324f6a6782f0b23e5e5e5e25ac1d1c8a97be1c9b89b4490dda80567a3f57c254314a185a01ca9f0fc94d82"
+  checksum: "sha512=0ad6a8777807d744ceb330e05989880422f6e2afa462571bff4e2d97b55ed7a0987998192e4ce289472b81112731bfdba0379b52e810fbe0851cc61a0e29b29e"
 }

--- a/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.3+8.17/opam
+++ b/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.3+8.17/opam
@@ -39,5 +39,5 @@ PCUIC: Weakening, Substitution, Confluence and Subject Reduction are proven here
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.3-8.17/metacoq-1.3-8.17.tar.gz"
-  checksum: "sha512=eef100ec9a30031d99e8f626f00fbd4d3156bc64e440086876c13490207e6fd845cf9c0688dc417feb4f4acd1c9ca7f3d467dd3250319090250c926e7c62fba0"
+  checksum: "sha512=ff4ed8a4cf33afb2a93c8ec07f00327f9924e82c81cb82ca74e0fe81b2199d5b13716fe5224fc0998952936c59ff0f52ed79703641745114a2ac777ab86beeb4"
 }

--- a/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.3.4+8.20/opam
+++ b/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.3.4+8.20/opam
@@ -38,6 +38,6 @@ with a certified typechecker for it. This module includes the standard metatheor
 PCUIC: Weakening, Substitution, Confluence and Subject Reduction are proven here.
 """
 url {
-  src: "https://github.com/MetaCoq/metacoq/archive/refs/tags/v1.3.4-8.20.tar.gz"
-  checksum: "sha512=fb3997e2e07e9c33c293aabcc06b8e69785a9c2ebdcd4d48f77e1eb09698da6ed1770127022843f89322cf8f78289acd67c860e1a2d9186d5703191ccd088429"
+  src: "https://github.com/MetaRocq/metarocq/releases/download/v1.3.4-8.20/metacoq-1.3.4-8.20.tar.gz"
+  checksum: "sha512=82d2a0cf514dce221557a3f63d024a1a020a8a6b20de7e859d1df3f58266ae432122545602a5a382ba4c21161e976c4cc0aa0b2601ee5a838b287883ebabc75a"
 }

--- a/released/packages/coq-metacoq-quotation/coq-metacoq-quotation.1.2+8.16/opam
+++ b/released/packages/coq-metacoq-quotation/coq-metacoq-quotation.1.2+8.16/opam
@@ -49,5 +49,5 @@ and `×`), which is sufficient for proving Löb's theorem.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2-8.16/metacoq-1.2-8.16.tar.gz"
-  checksum: "sha512=80739c1424f5c28afadfcc581fa7016bc26f28f3a8b79597abc52ba5cc404cbe3728cccb260ab5ff7ed71ecb9a66690bcaa8d9cc6c0b79d2d1b5e660c34d5008"
+  checksum: "sha512=ff42d9391a01c2cd37f98766cb430c2740161f3dc34c7588e471476b05293b5eb7d4e392c3b42e9f24604edfe251d403516047188012beca90d8f3601898d6af"
 }

--- a/released/packages/coq-metacoq-quotation/coq-metacoq-quotation.1.2+8.17/opam
+++ b/released/packages/coq-metacoq-quotation/coq-metacoq-quotation.1.2+8.17/opam
@@ -49,5 +49,5 @@ and `×`), which is sufficient for proving Löb's theorem.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2-8.17/metacoq-1.2-8.17.tar.gz"
-  checksum: "sha512=ef36dfe0e7864c67e223484f400f38531b41059c6e6e206a329b4dfa2c29e36ee133a711656fec3edcb37b046e5602d1a81c9989c399729f4547f19e854ccdbd"
+  checksum: "sha512=17add66108aadc1f8d9d513c92c94e94265cd10ad73d7999dd0ee2e53666094af7ec8aa9d93f089389576f2efc5fb4b23faad663319f814fbbc73aaf8e2bf999"
 }

--- a/released/packages/coq-metacoq-quotation/coq-metacoq-quotation.1.2.1+8.17/opam
+++ b/released/packages/coq-metacoq-quotation/coq-metacoq-quotation.1.2.1+8.17/opam
@@ -49,5 +49,5 @@ and `×`), which is sufficient for proving Löb's theorem.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2.1-8.17/metacoq-1.2.1-8.17.tar.gz"
-  checksum: "sha512=c02f106aafa1082bb6c2be5bb1c972840cd23d94c85541996767855e1a3080bc00405f463d275285847385680aa69b3798d067ed73e4712d8a137024cc256cab"
+  checksum: "sha512=c19536c0907711c28287844dcc469cb61ebda02c154c62174419b41fffc72ea58f8ac5a84711c6273b68b1d01f20741cc5c762501eddb8a1185befb6c4d15294"
 }

--- a/released/packages/coq-metacoq-quotation/coq-metacoq-quotation.1.2.1+8.18/opam
+++ b/released/packages/coq-metacoq-quotation/coq-metacoq-quotation.1.2.1+8.18/opam
@@ -49,5 +49,5 @@ and `×`), which is sufficient for proving Löb's theorem.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2.1-8.18/metacoq-1.2.1-8.18.tar.gz"
-  checksum: "sha512=3b2a6c1cb8005a7f675c47209b17f0b3f2ded6b3ae324f6a6782f0b23e5e5e5e25ac1d1c8a97be1c9b89b4490dda80567a3f57c254314a185a01ca9f0fc94d82"
+  checksum: "sha512=0ad6a8777807d744ceb330e05989880422f6e2afa462571bff4e2d97b55ed7a0987998192e4ce289472b81112731bfdba0379b52e810fbe0851cc61a0e29b29e"
 }

--- a/released/packages/coq-metacoq-quotation/coq-metacoq-quotation.1.3+8.17/opam
+++ b/released/packages/coq-metacoq-quotation/coq-metacoq-quotation.1.3+8.17/opam
@@ -49,5 +49,5 @@ and `×`), which is sufficient for proving Löb's theorem.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.3-8.17/metacoq-1.3-8.17.tar.gz"
-  checksum: "sha512=eef100ec9a30031d99e8f626f00fbd4d3156bc64e440086876c13490207e6fd845cf9c0688dc417feb4f4acd1c9ca7f3d467dd3250319090250c926e7c62fba0"
+  checksum: "sha512=ff4ed8a4cf33afb2a93c8ec07f00327f9924e82c81cb82ca74e0fe81b2199d5b13716fe5224fc0998952936c59ff0f52ed79703641745114a2ac777ab86beeb4"
 }

--- a/released/packages/coq-metacoq-quotation/coq-metacoq-quotation.1.3.4+8.20/opam
+++ b/released/packages/coq-metacoq-quotation/coq-metacoq-quotation.1.3.4+8.20/opam
@@ -48,6 +48,6 @@ semicomonad (a functor with `cojoin : □T → □□T` that codistributes over 
 and `×`), which is sufficient for proving Löb's theorem.
 """
 url {
-  src: "https://github.com/MetaCoq/metacoq/archive/refs/tags/v1.3.4-8.20.tar.gz"
-  checksum: "sha512=fb3997e2e07e9c33c293aabcc06b8e69785a9c2ebdcd4d48f77e1eb09698da6ed1770127022843f89322cf8f78289acd67c860e1a2d9186d5703191ccd088429"
+  src: "https://github.com/MetaRocq/metarocq/releases/download/v1.3.4-8.20/metacoq-1.3.4-8.20.tar.gz"
+  checksum: "sha512=82d2a0cf514dce221557a3f63d024a1a020a8a6b20de7e859d1df3f58266ae432122545602a5a382ba4c21161e976c4cc0aa0b2601ee5a838b287883ebabc75a"
 }

--- a/released/packages/coq-metacoq-safechecker-plugin/coq-metacoq-safechecker-plugin.1.2+8.16/opam
+++ b/released/packages/coq-metacoq-safechecker-plugin/coq-metacoq-safechecker-plugin.1.2+8.16/opam
@@ -44,5 +44,5 @@ thesis.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2-8.16/metacoq-1.2-8.16.tar.gz"
-  checksum: "sha512=80739c1424f5c28afadfcc581fa7016bc26f28f3a8b79597abc52ba5cc404cbe3728cccb260ab5ff7ed71ecb9a66690bcaa8d9cc6c0b79d2d1b5e660c34d5008"
+  checksum: "sha512=ff42d9391a01c2cd37f98766cb430c2740161f3dc34c7588e471476b05293b5eb7d4e392c3b42e9f24604edfe251d403516047188012beca90d8f3601898d6af"
 }

--- a/released/packages/coq-metacoq-safechecker-plugin/coq-metacoq-safechecker-plugin.1.2+8.17/opam
+++ b/released/packages/coq-metacoq-safechecker-plugin/coq-metacoq-safechecker-plugin.1.2+8.17/opam
@@ -44,5 +44,5 @@ thesis.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2-8.17/metacoq-1.2-8.17.tar.gz"
-  checksum: "sha512=ef36dfe0e7864c67e223484f400f38531b41059c6e6e206a329b4dfa2c29e36ee133a711656fec3edcb37b046e5602d1a81c9989c399729f4547f19e854ccdbd"
+  checksum: "sha512=17add66108aadc1f8d9d513c92c94e94265cd10ad73d7999dd0ee2e53666094af7ec8aa9d93f089389576f2efc5fb4b23faad663319f814fbbc73aaf8e2bf999"
 }

--- a/released/packages/coq-metacoq-safechecker-plugin/coq-metacoq-safechecker-plugin.1.2.1+8.17/opam
+++ b/released/packages/coq-metacoq-safechecker-plugin/coq-metacoq-safechecker-plugin.1.2.1+8.17/opam
@@ -44,5 +44,5 @@ thesis.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2.1-8.17/metacoq-1.2.1-8.17.tar.gz"
-  checksum: "sha512=c02f106aafa1082bb6c2be5bb1c972840cd23d94c85541996767855e1a3080bc00405f463d275285847385680aa69b3798d067ed73e4712d8a137024cc256cab"
+  checksum: "sha512=c19536c0907711c28287844dcc469cb61ebda02c154c62174419b41fffc72ea58f8ac5a84711c6273b68b1d01f20741cc5c762501eddb8a1185befb6c4d15294"
 }

--- a/released/packages/coq-metacoq-safechecker-plugin/coq-metacoq-safechecker-plugin.1.2.1+8.18/opam
+++ b/released/packages/coq-metacoq-safechecker-plugin/coq-metacoq-safechecker-plugin.1.2.1+8.18/opam
@@ -44,5 +44,5 @@ thesis.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2.1-8.18/metacoq-1.2.1-8.18.tar.gz"
-  checksum: "sha512=3b2a6c1cb8005a7f675c47209b17f0b3f2ded6b3ae324f6a6782f0b23e5e5e5e25ac1d1c8a97be1c9b89b4490dda80567a3f57c254314a185a01ca9f0fc94d82"
+  checksum: "sha512=0ad6a8777807d744ceb330e05989880422f6e2afa462571bff4e2d97b55ed7a0987998192e4ce289472b81112731bfdba0379b52e810fbe0851cc61a0e29b29e"
 }

--- a/released/packages/coq-metacoq-safechecker-plugin/coq-metacoq-safechecker-plugin.1.3+8.17/opam
+++ b/released/packages/coq-metacoq-safechecker-plugin/coq-metacoq-safechecker-plugin.1.3+8.17/opam
@@ -44,5 +44,5 @@ thesis.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.3-8.17/metacoq-1.3-8.17.tar.gz"
-  checksum: "sha512=eef100ec9a30031d99e8f626f00fbd4d3156bc64e440086876c13490207e6fd845cf9c0688dc417feb4f4acd1c9ca7f3d467dd3250319090250c926e7c62fba0"
+  checksum: "sha512=ff4ed8a4cf33afb2a93c8ec07f00327f9924e82c81cb82ca74e0fe81b2199d5b13716fe5224fc0998952936c59ff0f52ed79703641745114a2ac777ab86beeb4"
 }

--- a/released/packages/coq-metacoq-safechecker-plugin/coq-metacoq-safechecker-plugin.1.3.4+8.20/opam
+++ b/released/packages/coq-metacoq-safechecker-plugin/coq-metacoq-safechecker-plugin.1.3.4+8.20/opam
@@ -43,6 +43,6 @@ into a dummy `tBox` constructor, following closely P. Letouzey's PhD
 thesis.
 """
 url {
-  src: "https://github.com/MetaCoq/metacoq/archive/refs/tags/v1.3.4-8.20.tar.gz"
-  checksum: "sha512=fb3997e2e07e9c33c293aabcc06b8e69785a9c2ebdcd4d48f77e1eb09698da6ed1770127022843f89322cf8f78289acd67c860e1a2d9186d5703191ccd088429"
+  src: "https://github.com/MetaRocq/metarocq/releases/download/v1.3.4-8.20/metacoq-1.3.4-8.20.tar.gz"
+  checksum: "sha512=82d2a0cf514dce221557a3f63d024a1a020a8a6b20de7e859d1df3f58266ae432122545602a5a382ba4c21161e976c4cc0aa0b2601ee5a838b287883ebabc75a"
 }

--- a/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.0+8.14/opam
+++ b/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.0+8.14/opam
@@ -37,5 +37,5 @@ weak-head reduction, conversion and typechecking of Coq definitions and global e
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.0-8.14/metacoq-1.0-8.14.tar.gz"
-  checksum: "sha512=208a6ba9ca2f2e4b9968baca059e5c290d22d083c30591c53b70275b82478510327c27cd6980ddae6245e491a976ffcbbfa4d004767e6dc172a88f042f921698"
+  checksum: "sha512=7271ce4158054dc2b349e0642d714865ab63cc6a6fe054a19fa47d2b93441a1f59c7f60642917e8fce2a5ec998d9437a3959316a33ab6695fcaf052bc50d6ffd"
 }

--- a/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.0+8.15/opam
+++ b/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.0+8.15/opam
@@ -37,5 +37,5 @@ weak-head reduction, conversion and typechecking of Coq definitions and global e
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.0-8.15/metacoq-1.0-8.15.tar.gz"
-  checksum: "sha512=8bf61d638afcefa661f65a3e7384fdffef358bed4985a9df8d60dc200603172d1931ad94cbc028e82ba9b44778f59428e240e02642111765a4470a1202264224"
+  checksum: "sha512=4747d378d91bef1b248f137be6851a5acddb34968d913daeda923ca6a3a009c3dcccdcf497c33d94f113636e469ef5046e71a23115dc22ea2e6069b7de72f5fc"
 }

--- a/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.0+8.16/opam
+++ b/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.0+8.16/opam
@@ -36,5 +36,5 @@ weak-head reduction, conversion and typechecking of Coq definitions and global e
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.0-8.16/metacoq-1.0-8.16.tar.gz"
-  checksum: "sha512=44f9364cfb0a2995e0adadbdb181e53a1dccd98781ab1b9abdde7942ee4b15ea233bca97c28e3185c8492a8af7db7cfe57e34d535b94d5465b9f3c3c5eb3f4e7"
+  checksum: "sha512=7e36b16d5de8952c92046971c0bc57f80da3a4d88f39aa6cdfa13756c19513738374f2ab725c2bce7ceb87402e3026a76c79d2ee4dfcdd3fc4ffc8cd4f1f00c8"
 }

--- a/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.1+8.14/opam
+++ b/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.1+8.14/opam
@@ -37,5 +37,5 @@ weak-head reduction, conversion and typechecking of Coq definitions and global e
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1-8.14/metacoq-1.1-8.14.tar.gz"
-  checksum: "sha512=e5cc8a540c7a7bb2a783c41ed6f6808362bf27c781fbb1f609e2b8da881065eba7adb74cf99132aa40329f88fec7547e79a6fdef268e609604cf35e82dc7ee6a"
+  checksum: "sha512=48edab0cfa08c45e2c691d2c01abce1b97a0d15d2d957e90ca8f08dbc0f20d7d8019fb4fb85cf968439cb991f3297e9c2abf0a113a518a2a46fa54814a7d4aea"
 }

--- a/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.1+8.15/opam
+++ b/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.1+8.15/opam
@@ -37,5 +37,5 @@ weak-head reduction, conversion and typechecking of Coq definitions and global e
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1-8.15/metacoq-1.1-8.15.tar.gz"
-  checksum: "sha512=ebb88e267033fc6167f41d51ccb233c171eb70775ba3b04aa3c7517ff073be31dcdf331e9901897d6c3e5893f6d12ec48d5851d44c23b1ec8c7e7d3d505eb360"
+  checksum: "sha512=12ea0aff460c7eee07b5341ebcbf231c0f8aed9346842ad53c2244ab5ed865a0ecf6764116fbb26ecd3558f3de29c6054b8769d0c084b6d291a6b0e9a751c69a"
 }

--- a/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.1+8.16/opam
+++ b/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.1+8.16/opam
@@ -37,5 +37,5 @@ weak-head reduction, conversion and typechecking of Coq definitions and global e
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1-8.16/metacoq-1.1-8.16.tar.gz"
-  checksum: "sha512=aa984b616d5e91a264e765973ef02d8c180da282d7c87017fc2ca7f783ed819f0f62f5f96c1cab7f11fc2993cbb424f48c4a00a0bcdf0c98f19460cd7dcce5aa"
+  checksum: "sha512=89e9c6a2aaaf0512d981c1e2272bafc0a20a226a1e8834bf67a1054906f28aa1ce343da725e5e74e929d83c8685cd5222c879d6e6eb19124b26d3a3aea70d811"
 }

--- a/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.1.1+8.14/opam
+++ b/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.1.1+8.14/opam
@@ -37,5 +37,5 @@ weak-head reduction, conversion and typechecking of Coq definitions and global e
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1.1-8.14/metacoq-1.1.1-8.14.tar.gz"
-  checksum: "sha512=e54a9dc6a01dbe7c95343327e63eed8011366347bd02c29eca9426a6b8d955e5d0209df448e2f2fbb517e8b928f7d22276e55aae092bd3c4e9f4ba11bcac85c5"
+  checksum: "sha512=f9918b1cbe14b63350fad399ec8201c76c4e7af9082a39928f54285978ba21eba0e89a5e18f1a20fc867e41d80416863402a4de972b30aaf2627548fb27d4268"
 }

--- a/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.1.1+8.15/opam
+++ b/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.1.1+8.15/opam
@@ -37,5 +37,5 @@ weak-head reduction, conversion and typechecking of Coq definitions and global e
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1.1-8.15/metacoq-1.1.1-8.15.tar.gz"
-  checksum: "sha512=651f6f59cae604169a8c2fef48df75324791adf1becd881b36f01c5bc407a6fef9209d69f4c917d72e8c86f06ae2db976cfed6778be438786b14ab6daf771c25"
+  checksum: "sha512=05372e6e0d82fb7dd0bc2f3088aa6828b54f4c835526d52514f1d71d5d49b79a4506844de4a539bc951d7eb71f268e1f753a832e4ae4669f871c3b2323357ca0"
 }

--- a/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.1.1+8.16/opam
+++ b/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.1.1+8.16/opam
@@ -37,5 +37,5 @@ weak-head reduction, conversion and typechecking of Coq definitions and global e
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1.1-8.16/metacoq-1.1.1-8.16.tar.gz"
-  checksum: "sha512=babae48068b31833a695ddbf7cac1043ccab778dcb5ea1cd6db3277f77f994a926636b10e58254615c88d080f69fc1885ea11d5bc8743e313e621aab2c9e48db"
+  checksum: "sha512=778e5cc64d35b782559fb245853444b2f87b4b3580acc62921251f8dfebf11e2be81ad1f37bdc26421faf7fc2678478028c097cc0afa61e5574b3072d5288917"
 }

--- a/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.2+8.16/opam
+++ b/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.2+8.16/opam
@@ -38,5 +38,5 @@ weak-head reduction, conversion and typechecking of Coq definitions and global e
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2-8.16/metacoq-1.2-8.16.tar.gz"
-  checksum: "sha512=80739c1424f5c28afadfcc581fa7016bc26f28f3a8b79597abc52ba5cc404cbe3728cccb260ab5ff7ed71ecb9a66690bcaa8d9cc6c0b79d2d1b5e660c34d5008"
+  checksum: "sha512=ff42d9391a01c2cd37f98766cb430c2740161f3dc34c7588e471476b05293b5eb7d4e392c3b42e9f24604edfe251d403516047188012beca90d8f3601898d6af"
 }

--- a/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.2+8.17/opam
+++ b/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.2+8.17/opam
@@ -38,5 +38,5 @@ weak-head reduction, conversion and typechecking of Coq definitions and global e
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2-8.17/metacoq-1.2-8.17.tar.gz"
-  checksum: "sha512=ef36dfe0e7864c67e223484f400f38531b41059c6e6e206a329b4dfa2c29e36ee133a711656fec3edcb37b046e5602d1a81c9989c399729f4547f19e854ccdbd"
+  checksum: "sha512=17add66108aadc1f8d9d513c92c94e94265cd10ad73d7999dd0ee2e53666094af7ec8aa9d93f089389576f2efc5fb4b23faad663319f814fbbc73aaf8e2bf999"
 }

--- a/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.2.1+8.17/opam
+++ b/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.2.1+8.17/opam
@@ -38,5 +38,5 @@ weak-head reduction, conversion and typechecking of Coq definitions and global e
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2.1-8.17/metacoq-1.2.1-8.17.tar.gz"
-  checksum: "sha512=c02f106aafa1082bb6c2be5bb1c972840cd23d94c85541996767855e1a3080bc00405f463d275285847385680aa69b3798d067ed73e4712d8a137024cc256cab"
+  checksum: "sha512=c19536c0907711c28287844dcc469cb61ebda02c154c62174419b41fffc72ea58f8ac5a84711c6273b68b1d01f20741cc5c762501eddb8a1185befb6c4d15294"
 }

--- a/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.2.1+8.18/opam
+++ b/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.2.1+8.18/opam
@@ -38,5 +38,5 @@ weak-head reduction, conversion and typechecking of Coq definitions and global e
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2.1-8.18/metacoq-1.2.1-8.18.tar.gz"
-  checksum: "sha512=3b2a6c1cb8005a7f675c47209b17f0b3f2ded6b3ae324f6a6782f0b23e5e5e5e25ac1d1c8a97be1c9b89b4490dda80567a3f57c254314a185a01ca9f0fc94d82"
+  checksum: "sha512=0ad6a8777807d744ceb330e05989880422f6e2afa462571bff4e2d97b55ed7a0987998192e4ce289472b81112731bfdba0379b52e810fbe0851cc61a0e29b29e"
 }

--- a/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.3+8.17/opam
+++ b/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.3+8.17/opam
@@ -38,5 +38,5 @@ weak-head reduction, conversion and typechecking of Coq definitions and global e
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.3-8.17/metacoq-1.3-8.17.tar.gz"
-  checksum: "sha512=eef100ec9a30031d99e8f626f00fbd4d3156bc64e440086876c13490207e6fd845cf9c0688dc417feb4f4acd1c9ca7f3d467dd3250319090250c926e7c62fba0"
+  checksum: "sha512=ff4ed8a4cf33afb2a93c8ec07f00327f9924e82c81cb82ca74e0fe81b2199d5b13716fe5224fc0998952936c59ff0f52ed79703641745114a2ac777ab86beeb4"
 }

--- a/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.3.4+8.20/opam
+++ b/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.3.4+8.20/opam
@@ -37,6 +37,6 @@ The SafeChecker modules provides a correct implementation of
 weak-head reduction, conversion and typechecking of Coq definitions and global environments.
 """
 url {
-  src: "https://github.com/MetaCoq/metacoq/archive/refs/tags/v1.3.4-8.20.tar.gz"
-  checksum: "sha512=fb3997e2e07e9c33c293aabcc06b8e69785a9c2ebdcd4d48f77e1eb09698da6ed1770127022843f89322cf8f78289acd67c860e1a2d9186d5703191ccd088429"
+  src: "https://github.com/MetaRocq/metarocq/releases/download/v1.3.4-8.20/metacoq-1.3.4-8.20.tar.gz"
+  checksum: "sha512=82d2a0cf514dce221557a3f63d024a1a020a8a6b20de7e859d1df3f58266ae432122545602a5a382ba4c21161e976c4cc0aa0b2601ee5a838b287883ebabc75a"
 }

--- a/released/packages/coq-metacoq-template-pcuic/coq-metacoq-template-pcuic.1.2+8.16/opam
+++ b/released/packages/coq-metacoq-template-pcuic/coq-metacoq-template-pcuic.1.2+8.16/opam
@@ -35,5 +35,5 @@ description: """
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2-8.16/metacoq-1.2-8.16.tar.gz"
-  checksum: "sha512=80739c1424f5c28afadfcc581fa7016bc26f28f3a8b79597abc52ba5cc404cbe3728cccb260ab5ff7ed71ecb9a66690bcaa8d9cc6c0b79d2d1b5e660c34d5008"
+  checksum: "sha512=ff42d9391a01c2cd37f98766cb430c2740161f3dc34c7588e471476b05293b5eb7d4e392c3b42e9f24604edfe251d403516047188012beca90d8f3601898d6af"
 }

--- a/released/packages/coq-metacoq-template-pcuic/coq-metacoq-template-pcuic.1.2+8.17/opam
+++ b/released/packages/coq-metacoq-template-pcuic/coq-metacoq-template-pcuic.1.2+8.17/opam
@@ -35,5 +35,5 @@ description: """
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2-8.17/metacoq-1.2-8.17.tar.gz"
-  checksum: "sha512=ef36dfe0e7864c67e223484f400f38531b41059c6e6e206a329b4dfa2c29e36ee133a711656fec3edcb37b046e5602d1a81c9989c399729f4547f19e854ccdbd"
+  checksum: "sha512=17add66108aadc1f8d9d513c92c94e94265cd10ad73d7999dd0ee2e53666094af7ec8aa9d93f089389576f2efc5fb4b23faad663319f814fbbc73aaf8e2bf999"
 }

--- a/released/packages/coq-metacoq-template-pcuic/coq-metacoq-template-pcuic.1.2.1+8.17/opam
+++ b/released/packages/coq-metacoq-template-pcuic/coq-metacoq-template-pcuic.1.2.1+8.17/opam
@@ -35,5 +35,5 @@ description: """
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2.1-8.17/metacoq-1.2.1-8.17.tar.gz"
-  checksum: "sha512=c02f106aafa1082bb6c2be5bb1c972840cd23d94c85541996767855e1a3080bc00405f463d275285847385680aa69b3798d067ed73e4712d8a137024cc256cab"
+  checksum: "sha512=c19536c0907711c28287844dcc469cb61ebda02c154c62174419b41fffc72ea58f8ac5a84711c6273b68b1d01f20741cc5c762501eddb8a1185befb6c4d15294"
 }

--- a/released/packages/coq-metacoq-template-pcuic/coq-metacoq-template-pcuic.1.2.1+8.18/opam
+++ b/released/packages/coq-metacoq-template-pcuic/coq-metacoq-template-pcuic.1.2.1+8.18/opam
@@ -35,5 +35,5 @@ description: """
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2.1-8.18/metacoq-1.2.1-8.18.tar.gz"
-  checksum: "sha512=3b2a6c1cb8005a7f675c47209b17f0b3f2ded6b3ae324f6a6782f0b23e5e5e5e25ac1d1c8a97be1c9b89b4490dda80567a3f57c254314a185a01ca9f0fc94d82"
+  checksum: "sha512=0ad6a8777807d744ceb330e05989880422f6e2afa462571bff4e2d97b55ed7a0987998192e4ce289472b81112731bfdba0379b52e810fbe0851cc61a0e29b29e"
 }

--- a/released/packages/coq-metacoq-template-pcuic/coq-metacoq-template-pcuic.1.3+8.17/opam
+++ b/released/packages/coq-metacoq-template-pcuic/coq-metacoq-template-pcuic.1.3+8.17/opam
@@ -35,5 +35,5 @@ description: """
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.3-8.17/metacoq-1.3-8.17.tar.gz"
-  checksum: "sha512=eef100ec9a30031d99e8f626f00fbd4d3156bc64e440086876c13490207e6fd845cf9c0688dc417feb4f4acd1c9ca7f3d467dd3250319090250c926e7c62fba0"
+  checksum: "sha512=ff4ed8a4cf33afb2a93c8ec07f00327f9924e82c81cb82ca74e0fe81b2199d5b13716fe5224fc0998952936c59ff0f52ed79703641745114a2ac777ab86beeb4"
 }

--- a/released/packages/coq-metacoq-template-pcuic/coq-metacoq-template-pcuic.1.3.4+8.20/opam
+++ b/released/packages/coq-metacoq-template-pcuic/coq-metacoq-template-pcuic.1.3.4+8.20/opam
@@ -34,6 +34,6 @@ synopsis: "Translations between Template Coq and PCUIC and proofs of correctness
 description: """
 """
 url {
-  src: "https://github.com/MetaCoq/metacoq/archive/refs/tags/v1.3.4-8.20.tar.gz"
-  checksum: "sha512=fb3997e2e07e9c33c293aabcc06b8e69785a9c2ebdcd4d48f77e1eb09698da6ed1770127022843f89322cf8f78289acd67c860e1a2d9186d5703191ccd088429"
+  src: "https://github.com/MetaRocq/metarocq/releases/download/v1.3.4-8.20/metacoq-1.3.4-8.20.tar.gz"
+  checksum: "sha512=82d2a0cf514dce221557a3f63d024a1a020a8a6b20de7e859d1df3f58266ae432122545602a5a382ba4c21161e976c4cc0aa0b2601ee5a838b287883ebabc75a"
 }

--- a/released/packages/coq-metacoq-template/coq-metacoq-template.1.0+8.14/opam
+++ b/released/packages/coq-metacoq-template/coq-metacoq-template.1.0+8.14/opam
@@ -50,5 +50,5 @@ Template Coq includes:
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.0-8.14/metacoq-1.0-8.14.tar.gz"
-  checksum: "sha512=208a6ba9ca2f2e4b9968baca059e5c290d22d083c30591c53b70275b82478510327c27cd6980ddae6245e491a976ffcbbfa4d004767e6dc172a88f042f921698"
+  checksum: "sha512=7271ce4158054dc2b349e0642d714865ab63cc6a6fe054a19fa47d2b93441a1f59c7f60642917e8fce2a5ec998d9437a3959316a33ab6695fcaf052bc50d6ffd"
 }

--- a/released/packages/coq-metacoq-template/coq-metacoq-template.1.0+8.15/opam
+++ b/released/packages/coq-metacoq-template/coq-metacoq-template.1.0+8.15/opam
@@ -50,5 +50,5 @@ Template Coq includes:
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.0-8.15/metacoq-1.0-8.15.tar.gz"
-  checksum: "sha512=8bf61d638afcefa661f65a3e7384fdffef358bed4985a9df8d60dc200603172d1931ad94cbc028e82ba9b44778f59428e240e02642111765a4470a1202264224"
+  checksum: "sha512=4747d378d91bef1b248f137be6851a5acddb34968d913daeda923ca6a3a009c3dcccdcf497c33d94f113636e469ef5046e71a23115dc22ea2e6069b7de72f5fc"
 }

--- a/released/packages/coq-metacoq-template/coq-metacoq-template.1.0+8.16/opam
+++ b/released/packages/coq-metacoq-template/coq-metacoq-template.1.0+8.16/opam
@@ -48,5 +48,5 @@ Template Coq includes:
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.0-8.16/metacoq-1.0-8.16.tar.gz"
-  checksum: "sha512=44f9364cfb0a2995e0adadbdb181e53a1dccd98781ab1b9abdde7942ee4b15ea233bca97c28e3185c8492a8af7db7cfe57e34d535b94d5465b9f3c3c5eb3f4e7"
+  checksum: "sha512=7e36b16d5de8952c92046971c0bc57f80da3a4d88f39aa6cdfa13756c19513738374f2ab725c2bce7ceb87402e3026a76c79d2ee4dfcdd3fc4ffc8cd4f1f00c8"
 }

--- a/released/packages/coq-metacoq-template/coq-metacoq-template.1.1+8.14/opam
+++ b/released/packages/coq-metacoq-template/coq-metacoq-template.1.1+8.14/opam
@@ -50,5 +50,5 @@ Template Coq includes:
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1-8.14/metacoq-1.1-8.14.tar.gz"
-  checksum: "sha512=e5cc8a540c7a7bb2a783c41ed6f6808362bf27c781fbb1f609e2b8da881065eba7adb74cf99132aa40329f88fec7547e79a6fdef268e609604cf35e82dc7ee6a"
+  checksum: "sha512=48edab0cfa08c45e2c691d2c01abce1b97a0d15d2d957e90ca8f08dbc0f20d7d8019fb4fb85cf968439cb991f3297e9c2abf0a113a518a2a46fa54814a7d4aea"
 }

--- a/released/packages/coq-metacoq-template/coq-metacoq-template.1.1+8.15/opam
+++ b/released/packages/coq-metacoq-template/coq-metacoq-template.1.1+8.15/opam
@@ -50,5 +50,5 @@ Template Coq includes:
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1-8.15/metacoq-1.1-8.15.tar.gz"
-  checksum: "sha512=ebb88e267033fc6167f41d51ccb233c171eb70775ba3b04aa3c7517ff073be31dcdf331e9901897d6c3e5893f6d12ec48d5851d44c23b1ec8c7e7d3d505eb360"
+  checksum: "sha512=12ea0aff460c7eee07b5341ebcbf231c0f8aed9346842ad53c2244ab5ed865a0ecf6764116fbb26ecd3558f3de29c6054b8769d0c084b6d291a6b0e9a751c69a"
 }

--- a/released/packages/coq-metacoq-template/coq-metacoq-template.1.1+8.16/opam
+++ b/released/packages/coq-metacoq-template/coq-metacoq-template.1.1+8.16/opam
@@ -52,7 +52,7 @@ Template Coq includes:
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1-8.16/metacoq-1.1-8.16.tar.gz"
-  checksum: "sha512=aa984b616d5e91a264e765973ef02d8c180da282d7c87017fc2ca7f783ed819f0f62f5f96c1cab7f11fc2993cbb424f48c4a00a0bcdf0c98f19460cd7dcce5aa"
+  checksum: "sha512=89e9c6a2aaaf0512d981c1e2272bafc0a20a226a1e8834bf67a1054906f28aa1ce343da725e5e74e929d83c8685cd5222c879d6e6eb19124b26d3a3aea70d811"
 }
 extra-files: [
   "0001-Fix-line-ending-issues-with-generated-code-on-Window.patch"

--- a/released/packages/coq-metacoq-template/coq-metacoq-template.1.1.1+8.14/opam
+++ b/released/packages/coq-metacoq-template/coq-metacoq-template.1.1.1+8.14/opam
@@ -50,5 +50,5 @@ Template Coq includes:
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1.1-8.14/metacoq-1.1.1-8.14.tar.gz"
-  checksum: "sha512=e54a9dc6a01dbe7c95343327e63eed8011366347bd02c29eca9426a6b8d955e5d0209df448e2f2fbb517e8b928f7d22276e55aae092bd3c4e9f4ba11bcac85c5"
+  checksum: "sha512=f9918b1cbe14b63350fad399ec8201c76c4e7af9082a39928f54285978ba21eba0e89a5e18f1a20fc867e41d80416863402a4de972b30aaf2627548fb27d4268"
 }

--- a/released/packages/coq-metacoq-template/coq-metacoq-template.1.1.1+8.15/opam
+++ b/released/packages/coq-metacoq-template/coq-metacoq-template.1.1.1+8.15/opam
@@ -50,5 +50,5 @@ Template Coq includes:
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1.1-8.15/metacoq-1.1.1-8.15.tar.gz"
-  checksum: "sha512=651f6f59cae604169a8c2fef48df75324791adf1becd881b36f01c5bc407a6fef9209d69f4c917d72e8c86f06ae2db976cfed6778be438786b14ab6daf771c25"
+  checksum: "sha512=05372e6e0d82fb7dd0bc2f3088aa6828b54f4c835526d52514f1d71d5d49b79a4506844de4a539bc951d7eb71f268e1f753a832e4ae4669f871c3b2323357ca0"
 }

--- a/released/packages/coq-metacoq-template/coq-metacoq-template.1.1.1+8.16/opam
+++ b/released/packages/coq-metacoq-template/coq-metacoq-template.1.1.1+8.16/opam
@@ -49,5 +49,5 @@ Template Coq includes:
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1.1-8.16/metacoq-1.1.1-8.16.tar.gz"
-  checksum: "sha512=babae48068b31833a695ddbf7cac1043ccab778dcb5ea1cd6db3277f77f994a926636b10e58254615c88d080f69fc1885ea11d5bc8743e313e621aab2c9e48db"
+  checksum: "sha512=778e5cc64d35b782559fb245853444b2f87b4b3580acc62921251f8dfebf11e2be81ad1f37bdc26421faf7fc2678478028c097cc0afa61e5574b3072d5288917"
 }

--- a/released/packages/coq-metacoq-template/coq-metacoq-template.1.2+8.16/opam
+++ b/released/packages/coq-metacoq-template/coq-metacoq-template.1.2+8.16/opam
@@ -48,5 +48,5 @@ Template Coq includes:
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2-8.16/metacoq-1.2-8.16.tar.gz"
-  checksum: "sha512=80739c1424f5c28afadfcc581fa7016bc26f28f3a8b79597abc52ba5cc404cbe3728cccb260ab5ff7ed71ecb9a66690bcaa8d9cc6c0b79d2d1b5e660c34d5008"
+  checksum: "sha512=ff42d9391a01c2cd37f98766cb430c2740161f3dc34c7588e471476b05293b5eb7d4e392c3b42e9f24604edfe251d403516047188012beca90d8f3601898d6af"
 }

--- a/released/packages/coq-metacoq-template/coq-metacoq-template.1.2+8.17/opam
+++ b/released/packages/coq-metacoq-template/coq-metacoq-template.1.2+8.17/opam
@@ -48,5 +48,5 @@ Template Coq includes:
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2-8.17/metacoq-1.2-8.17.tar.gz"
-  checksum: "sha512=ef36dfe0e7864c67e223484f400f38531b41059c6e6e206a329b4dfa2c29e36ee133a711656fec3edcb37b046e5602d1a81c9989c399729f4547f19e854ccdbd"
+  checksum: "sha512=17add66108aadc1f8d9d513c92c94e94265cd10ad73d7999dd0ee2e53666094af7ec8aa9d93f089389576f2efc5fb4b23faad663319f814fbbc73aaf8e2bf999"
 }

--- a/released/packages/coq-metacoq-template/coq-metacoq-template.1.2.1+8.17/opam
+++ b/released/packages/coq-metacoq-template/coq-metacoq-template.1.2.1+8.17/opam
@@ -48,5 +48,5 @@ Template Coq includes:
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2.1-8.17/metacoq-1.2.1-8.17.tar.gz"
-  checksum: "sha512=c02f106aafa1082bb6c2be5bb1c972840cd23d94c85541996767855e1a3080bc00405f463d275285847385680aa69b3798d067ed73e4712d8a137024cc256cab"
+  checksum: "sha512=c19536c0907711c28287844dcc469cb61ebda02c154c62174419b41fffc72ea58f8ac5a84711c6273b68b1d01f20741cc5c762501eddb8a1185befb6c4d15294"
 }

--- a/released/packages/coq-metacoq-template/coq-metacoq-template.1.2.1+8.18/opam
+++ b/released/packages/coq-metacoq-template/coq-metacoq-template.1.2.1+8.18/opam
@@ -48,5 +48,5 @@ Template Coq includes:
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2.1-8.18/metacoq-1.2.1-8.18.tar.gz"
-  checksum: "sha512=3b2a6c1cb8005a7f675c47209b17f0b3f2ded6b3ae324f6a6782f0b23e5e5e5e25ac1d1c8a97be1c9b89b4490dda80567a3f57c254314a185a01ca9f0fc94d82"
+  checksum: "sha512=0ad6a8777807d744ceb330e05989880422f6e2afa462571bff4e2d97b55ed7a0987998192e4ce289472b81112731bfdba0379b52e810fbe0851cc61a0e29b29e"
 }

--- a/released/packages/coq-metacoq-template/coq-metacoq-template.1.3+8.17/opam
+++ b/released/packages/coq-metacoq-template/coq-metacoq-template.1.3+8.17/opam
@@ -48,5 +48,5 @@ Template Coq includes:
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.3-8.17/metacoq-1.3-8.17.tar.gz"
-  checksum: "sha512=eef100ec9a30031d99e8f626f00fbd4d3156bc64e440086876c13490207e6fd845cf9c0688dc417feb4f4acd1c9ca7f3d467dd3250319090250c926e7c62fba0"
+  checksum: "sha512=ff4ed8a4cf33afb2a93c8ec07f00327f9924e82c81cb82ca74e0fe81b2199d5b13716fe5224fc0998952936c59ff0f52ed79703641745114a2ac777ab86beeb4"
 }

--- a/released/packages/coq-metacoq-template/coq-metacoq-template.1.3.4+8.20/opam
+++ b/released/packages/coq-metacoq-template/coq-metacoq-template.1.3.4+8.20/opam
@@ -47,6 +47,6 @@ Template Coq includes:
   MetaCoq/MTac.
 """
 url {
-  src: "https://github.com/MetaCoq/metacoq/archive/refs/tags/v1.3.4-8.20.tar.gz"
-  checksum: "sha512=fb3997e2e07e9c33c293aabcc06b8e69785a9c2ebdcd4d48f77e1eb09698da6ed1770127022843f89322cf8f78289acd67c860e1a2d9186d5703191ccd088429"
+  src: "https://github.com/MetaRocq/metarocq/releases/download/v1.3.4-8.20/metacoq-1.3.4-8.20.tar.gz"
+  checksum: "sha512=82d2a0cf514dce221557a3f63d024a1a020a8a6b20de7e859d1df3f58266ae432122545602a5a382ba4c21161e976c4cc0aa0b2601ee5a838b287883ebabc75a"
 }

--- a/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0+8.14/opam
+++ b/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0+8.14/opam
@@ -38,5 +38,5 @@ translation that invalidates functional extensionality.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.0-8.14/metacoq-1.0-8.14.tar.gz"
-  checksum: "sha512=208a6ba9ca2f2e4b9968baca059e5c290d22d083c30591c53b70275b82478510327c27cd6980ddae6245e491a976ffcbbfa4d004767e6dc172a88f042f921698"
+  checksum: "sha512=7271ce4158054dc2b349e0642d714865ab63cc6a6fe054a19fa47d2b93441a1f59c7f60642917e8fce2a5ec998d9437a3959316a33ab6695fcaf052bc50d6ffd"
 }

--- a/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0+8.15/opam
+++ b/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0+8.15/opam
@@ -38,5 +38,5 @@ translation that invalidates functional extensionality.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.0-8.15/metacoq-1.0-8.15.tar.gz"
-  checksum: "sha512=8bf61d638afcefa661f65a3e7384fdffef358bed4985a9df8d60dc200603172d1931ad94cbc028e82ba9b44778f59428e240e02642111765a4470a1202264224"
+  checksum: "sha512=4747d378d91bef1b248f137be6851a5acddb34968d913daeda923ca6a3a009c3dcccdcf497c33d94f113636e469ef5046e71a23115dc22ea2e6069b7de72f5fc"
 }

--- a/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0+8.16/opam
+++ b/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0+8.16/opam
@@ -38,7 +38,7 @@ translation that invalidates functional extensionality.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.0-8.16/metacoq-1.0-8.16.tar.gz"
-  checksum: "sha512=44f9364cfb0a2995e0adadbdb181e53a1dccd98781ab1b9abdde7942ee4b15ea233bca97c28e3185c8492a8af7db7cfe57e34d535b94d5465b9f3c3c5eb3f4e7"
+  checksum: "sha512=7e36b16d5de8952c92046971c0bc57f80da3a4d88f39aa6cdfa13756c19513738374f2ab725c2bce7ceb87402e3026a76c79d2ee4dfcdd3fc4ffc8cd4f1f00c8"
 }
 extra-files: [
   "fix-build.patch"

--- a/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.1+8.14/opam
+++ b/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.1+8.14/opam
@@ -38,5 +38,5 @@ translation that invalidates functional extensionality.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1-8.14/metacoq-1.1-8.14.tar.gz"
-  checksum: "sha512=e5cc8a540c7a7bb2a783c41ed6f6808362bf27c781fbb1f609e2b8da881065eba7adb74cf99132aa40329f88fec7547e79a6fdef268e609604cf35e82dc7ee6a"
+  checksum: "sha512=48edab0cfa08c45e2c691d2c01abce1b97a0d15d2d957e90ca8f08dbc0f20d7d8019fb4fb85cf968439cb991f3297e9c2abf0a113a518a2a46fa54814a7d4aea"
 }

--- a/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.1+8.15/opam
+++ b/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.1+8.15/opam
@@ -38,5 +38,5 @@ translation that invalidates functional extensionality.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1-8.15/metacoq-1.1-8.15.tar.gz"
-  checksum: "sha512=ebb88e267033fc6167f41d51ccb233c171eb70775ba3b04aa3c7517ff073be31dcdf331e9901897d6c3e5893f6d12ec48d5851d44c23b1ec8c7e7d3d505eb360"
+  checksum: "sha512=12ea0aff460c7eee07b5341ebcbf231c0f8aed9346842ad53c2244ab5ed865a0ecf6764116fbb26ecd3558f3de29c6054b8769d0c084b6d291a6b0e9a751c69a"
 }

--- a/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.1+8.16/opam
+++ b/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.1+8.16/opam
@@ -38,5 +38,5 @@ translation that invalidates functional extensionality.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1-8.16/metacoq-1.1-8.16.tar.gz"
-  checksum: "sha512=aa984b616d5e91a264e765973ef02d8c180da282d7c87017fc2ca7f783ed819f0f62f5f96c1cab7f11fc2993cbb424f48c4a00a0bcdf0c98f19460cd7dcce5aa"
+  checksum: "sha512=89e9c6a2aaaf0512d981c1e2272bafc0a20a226a1e8834bf67a1054906f28aa1ce343da725e5e74e929d83c8685cd5222c879d6e6eb19124b26d3a3aea70d811"
 }

--- a/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.1.1+8.14/opam
+++ b/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.1.1+8.14/opam
@@ -38,5 +38,5 @@ translation that invalidates functional extensionality.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1.1-8.14/metacoq-1.1.1-8.14.tar.gz"
-  checksum: "sha512=e54a9dc6a01dbe7c95343327e63eed8011366347bd02c29eca9426a6b8d955e5d0209df448e2f2fbb517e8b928f7d22276e55aae092bd3c4e9f4ba11bcac85c5"
+  checksum: "sha512=f9918b1cbe14b63350fad399ec8201c76c4e7af9082a39928f54285978ba21eba0e89a5e18f1a20fc867e41d80416863402a4de972b30aaf2627548fb27d4268"
 }

--- a/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.1.1+8.15/opam
+++ b/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.1.1+8.15/opam
@@ -38,5 +38,5 @@ translation that invalidates functional extensionality.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1.1-8.15/metacoq-1.1.1-8.15.tar.gz"
-  checksum: "sha512=651f6f59cae604169a8c2fef48df75324791adf1becd881b36f01c5bc407a6fef9209d69f4c917d72e8c86f06ae2db976cfed6778be438786b14ab6daf771c25"
+  checksum: "sha512=05372e6e0d82fb7dd0bc2f3088aa6828b54f4c835526d52514f1d71d5d49b79a4506844de4a539bc951d7eb71f268e1f753a832e4ae4669f871c3b2323357ca0"
 }

--- a/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.1.1+8.16/opam
+++ b/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.1.1+8.16/opam
@@ -38,5 +38,5 @@ translation that invalidates functional extensionality.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1.1-8.16/metacoq-1.1.1-8.16.tar.gz"
-  checksum: "sha512=babae48068b31833a695ddbf7cac1043ccab778dcb5ea1cd6db3277f77f994a926636b10e58254615c88d080f69fc1885ea11d5bc8743e313e621aab2c9e48db"
+  checksum: "sha512=778e5cc64d35b782559fb245853444b2f87b4b3580acc62921251f8dfebf11e2be81ad1f37bdc26421faf7fc2678478028c097cc0afa61e5574b3072d5288917"
 }

--- a/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.2+8.16/opam
+++ b/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.2+8.16/opam
@@ -39,5 +39,5 @@ translation that invalidates functional extensionality.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2-8.16/metacoq-1.2-8.16.tar.gz"
-  checksum: "sha512=80739c1424f5c28afadfcc581fa7016bc26f28f3a8b79597abc52ba5cc404cbe3728cccb260ab5ff7ed71ecb9a66690bcaa8d9cc6c0b79d2d1b5e660c34d5008"
+  checksum: "sha512=ff42d9391a01c2cd37f98766cb430c2740161f3dc34c7588e471476b05293b5eb7d4e392c3b42e9f24604edfe251d403516047188012beca90d8f3601898d6af"
 }

--- a/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.2+8.17/opam
+++ b/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.2+8.17/opam
@@ -39,5 +39,5 @@ translation that invalidates functional extensionality.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2-8.17/metacoq-1.2-8.17.tar.gz"
-  checksum: "sha512=ef36dfe0e7864c67e223484f400f38531b41059c6e6e206a329b4dfa2c29e36ee133a711656fec3edcb37b046e5602d1a81c9989c399729f4547f19e854ccdbd"
+  checksum: "sha512=17add66108aadc1f8d9d513c92c94e94265cd10ad73d7999dd0ee2e53666094af7ec8aa9d93f089389576f2efc5fb4b23faad663319f814fbbc73aaf8e2bf999"
 }

--- a/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.2.1+8.17/opam
+++ b/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.2.1+8.17/opam
@@ -39,5 +39,5 @@ translation that invalidates functional extensionality.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2.1-8.17/metacoq-1.2.1-8.17.tar.gz"
-  checksum: "sha512=c02f106aafa1082bb6c2be5bb1c972840cd23d94c85541996767855e1a3080bc00405f463d275285847385680aa69b3798d067ed73e4712d8a137024cc256cab"
+  checksum: "sha512=c19536c0907711c28287844dcc469cb61ebda02c154c62174419b41fffc72ea58f8ac5a84711c6273b68b1d01f20741cc5c762501eddb8a1185befb6c4d15294"
 }

--- a/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.2.1+8.18/opam
+++ b/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.2.1+8.18/opam
@@ -39,5 +39,5 @@ translation that invalidates functional extensionality.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2.1-8.18/metacoq-1.2.1-8.18.tar.gz"
-  checksum: "sha512=3b2a6c1cb8005a7f675c47209b17f0b3f2ded6b3ae324f6a6782f0b23e5e5e5e25ac1d1c8a97be1c9b89b4490dda80567a3f57c254314a185a01ca9f0fc94d82"
+  checksum: "sha512=0ad6a8777807d744ceb330e05989880422f6e2afa462571bff4e2d97b55ed7a0987998192e4ce289472b81112731bfdba0379b52e810fbe0851cc61a0e29b29e"
 }

--- a/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.3+8.17/opam
+++ b/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.3+8.17/opam
@@ -39,5 +39,5 @@ translation that invalidates functional extensionality.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.3-8.17/metacoq-1.3-8.17.tar.gz"
-  checksum: "sha512=eef100ec9a30031d99e8f626f00fbd4d3156bc64e440086876c13490207e6fd845cf9c0688dc417feb4f4acd1c9ca7f3d467dd3250319090250c926e7c62fba0"
+  checksum: "sha512=ff4ed8a4cf33afb2a93c8ec07f00327f9924e82c81cb82ca74e0fe81b2199d5b13716fe5224fc0998952936c59ff0f52ed79703641745114a2ac777ab86beeb4"
 }

--- a/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.3.4+8.20/opam
+++ b/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.3.4+8.20/opam
@@ -38,6 +38,6 @@ from type theory to type theory, e.g. parametricity and the `cross-bool`
 translation that invalidates functional extensionality.
 """
 url {
-  src: "https://github.com/MetaCoq/metacoq/archive/refs/tags/v1.3.4-8.20.tar.gz"
-  checksum: "sha512=fb3997e2e07e9c33c293aabcc06b8e69785a9c2ebdcd4d48f77e1eb09698da6ed1770127022843f89322cf8f78289acd67c860e1a2d9186d5703191ccd088429"
+  src: "https://github.com/MetaRocq/metarocq/releases/download/v1.3.4-8.20/metacoq-1.3.4-8.20.tar.gz"
+  checksum: "sha512=82d2a0cf514dce221557a3f63d024a1a020a8a6b20de7e859d1df3f58266ae432122545602a5a382ba4c21161e976c4cc0aa0b2601ee5a838b287883ebabc75a"
 }

--- a/released/packages/coq-metacoq-utils/coq-metacoq-utils.1.2+8.16/opam
+++ b/released/packages/coq-metacoq-utils/coq-metacoq-utils.1.2+8.16/opam
@@ -37,5 +37,5 @@ MetaCoq is a meta-programming framework for Coq.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2-8.16/metacoq-1.2-8.16.tar.gz"
-  checksum: "sha512=80739c1424f5c28afadfcc581fa7016bc26f28f3a8b79597abc52ba5cc404cbe3728cccb260ab5ff7ed71ecb9a66690bcaa8d9cc6c0b79d2d1b5e660c34d5008"
+  checksum: "sha512=ff42d9391a01c2cd37f98766cb430c2740161f3dc34c7588e471476b05293b5eb7d4e392c3b42e9f24604edfe251d403516047188012beca90d8f3601898d6af"
 }

--- a/released/packages/coq-metacoq-utils/coq-metacoq-utils.1.2+8.17/opam
+++ b/released/packages/coq-metacoq-utils/coq-metacoq-utils.1.2+8.17/opam
@@ -37,5 +37,5 @@ MetaCoq is a meta-programming framework for Coq.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2-8.17/metacoq-1.2-8.17.tar.gz"
-  checksum: "sha512=ef36dfe0e7864c67e223484f400f38531b41059c6e6e206a329b4dfa2c29e36ee133a711656fec3edcb37b046e5602d1a81c9989c399729f4547f19e854ccdbd"
+  checksum: "sha512=17add66108aadc1f8d9d513c92c94e94265cd10ad73d7999dd0ee2e53666094af7ec8aa9d93f089389576f2efc5fb4b23faad663319f814fbbc73aaf8e2bf999"
 }

--- a/released/packages/coq-metacoq-utils/coq-metacoq-utils.1.2.1+8.17/opam
+++ b/released/packages/coq-metacoq-utils/coq-metacoq-utils.1.2.1+8.17/opam
@@ -37,5 +37,5 @@ MetaCoq is a meta-programming framework for Coq.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2.1-8.17/metacoq-1.2.1-8.17.tar.gz"
-  checksum: "sha512=c02f106aafa1082bb6c2be5bb1c972840cd23d94c85541996767855e1a3080bc00405f463d275285847385680aa69b3798d067ed73e4712d8a137024cc256cab"
+  checksum: "sha512=c19536c0907711c28287844dcc469cb61ebda02c154c62174419b41fffc72ea58f8ac5a84711c6273b68b1d01f20741cc5c762501eddb8a1185befb6c4d15294"
 }

--- a/released/packages/coq-metacoq-utils/coq-metacoq-utils.1.2.1+8.18/opam
+++ b/released/packages/coq-metacoq-utils/coq-metacoq-utils.1.2.1+8.18/opam
@@ -37,5 +37,5 @@ MetaCoq is a meta-programming framework for Coq.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2.1-8.18/metacoq-1.2.1-8.18.tar.gz"
-  checksum: "sha512=3b2a6c1cb8005a7f675c47209b17f0b3f2ded6b3ae324f6a6782f0b23e5e5e5e25ac1d1c8a97be1c9b89b4490dda80567a3f57c254314a185a01ca9f0fc94d82"
+  checksum: "sha512=0ad6a8777807d744ceb330e05989880422f6e2afa462571bff4e2d97b55ed7a0987998192e4ce289472b81112731bfdba0379b52e810fbe0851cc61a0e29b29e"
 }

--- a/released/packages/coq-metacoq-utils/coq-metacoq-utils.1.3+8.17/opam
+++ b/released/packages/coq-metacoq-utils/coq-metacoq-utils.1.3+8.17/opam
@@ -37,5 +37,5 @@ MetaCoq is a meta-programming framework for Coq.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.3-8.17/metacoq-1.3-8.17.tar.gz"
-  checksum: "sha512=eef100ec9a30031d99e8f626f00fbd4d3156bc64e440086876c13490207e6fd845cf9c0688dc417feb4f4acd1c9ca7f3d467dd3250319090250c926e7c62fba0"
+  checksum: "sha512=ff4ed8a4cf33afb2a93c8ec07f00327f9924e82c81cb82ca74e0fe81b2199d5b13716fe5224fc0998952936c59ff0f52ed79703641745114a2ac777ab86beeb4"
 }

--- a/released/packages/coq-metacoq-utils/coq-metacoq-utils.1.3.4+8.20/opam
+++ b/released/packages/coq-metacoq-utils/coq-metacoq-utils.1.3.4+8.20/opam
@@ -35,6 +35,6 @@ description: """
 MetaCoq is a meta-programming framework for Coq.
 """
 url {
-  src: "https://github.com/MetaCoq/metacoq/archive/refs/tags/v1.3.4-8.20.tar.gz"
-  checksum: "sha512=fb3997e2e07e9c33c293aabcc06b8e69785a9c2ebdcd4d48f77e1eb09698da6ed1770127022843f89322cf8f78289acd67c860e1a2d9186d5703191ccd088429"
+  src: "https://github.com/MetaRocq/metarocq/releases/download/v1.3.4-8.20/metacoq-1.3.4-8.20.tar.gz"
+  checksum: "sha512=82d2a0cf514dce221557a3f63d024a1a020a8a6b20de7e859d1df3f58266ae432122545602a5a382ba4c21161e976c4cc0aa0b2601ee5a838b287883ebabc75a"
 }

--- a/released/packages/coq-metacoq/coq-metacoq.1.0+8.14/opam
+++ b/released/packages/coq-metacoq/coq-metacoq.1.0+8.14/opam
@@ -42,5 +42,5 @@ See individual packages for more detailed descriptions.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.0-8.14/metacoq-1.0-8.14.tar.gz"
-  checksum: "sha512=208a6ba9ca2f2e4b9968baca059e5c290d22d083c30591c53b70275b82478510327c27cd6980ddae6245e491a976ffcbbfa4d004767e6dc172a88f042f921698"
+  checksum: "sha512=7271ce4158054dc2b349e0642d714865ab63cc6a6fe054a19fa47d2b93441a1f59c7f60642917e8fce2a5ec998d9437a3959316a33ab6695fcaf052bc50d6ffd"
 }

--- a/released/packages/coq-metacoq/coq-metacoq.1.0+8.15/opam
+++ b/released/packages/coq-metacoq/coq-metacoq.1.0+8.15/opam
@@ -42,5 +42,5 @@ See individual packages for more detailed descriptions.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.0-8.15/metacoq-1.0-8.15.tar.gz"
-  checksum: "sha512=8bf61d638afcefa661f65a3e7384fdffef358bed4985a9df8d60dc200603172d1931ad94cbc028e82ba9b44778f59428e240e02642111765a4470a1202264224"
+  checksum: "sha512=4747d378d91bef1b248f137be6851a5acddb34968d913daeda923ca6a3a009c3dcccdcf497c33d94f113636e469ef5046e71a23115dc22ea2e6069b7de72f5fc"
 }

--- a/released/packages/coq-metacoq/coq-metacoq.1.0+8.16/opam
+++ b/released/packages/coq-metacoq/coq-metacoq.1.0+8.16/opam
@@ -36,5 +36,5 @@ See individual packages for more detailed descriptions.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.0-8.16/metacoq-1.0-8.16.tar.gz"
-  checksum: "sha512=44f9364cfb0a2995e0adadbdb181e53a1dccd98781ab1b9abdde7942ee4b15ea233bca97c28e3185c8492a8af7db7cfe57e34d535b94d5465b9f3c3c5eb3f4e7"
+  checksum: "sha512=7e36b16d5de8952c92046971c0bc57f80da3a4d88f39aa6cdfa13756c19513738374f2ab725c2bce7ceb87402e3026a76c79d2ee4dfcdd3fc4ffc8cd4f1f00c8"
 }

--- a/released/packages/coq-metacoq/coq-metacoq.1.1+8.14/opam
+++ b/released/packages/coq-metacoq/coq-metacoq.1.1+8.14/opam
@@ -42,5 +42,5 @@ See individual packages for more detailed descriptions.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1-8.14/metacoq-1.1-8.14.tar.gz"
-  checksum: "sha512=e5cc8a540c7a7bb2a783c41ed6f6808362bf27c781fbb1f609e2b8da881065eba7adb74cf99132aa40329f88fec7547e79a6fdef268e609604cf35e82dc7ee6a"
+  checksum: "sha512=48edab0cfa08c45e2c691d2c01abce1b97a0d15d2d957e90ca8f08dbc0f20d7d8019fb4fb85cf968439cb991f3297e9c2abf0a113a518a2a46fa54814a7d4aea"
 }

--- a/released/packages/coq-metacoq/coq-metacoq.1.1+8.15/opam
+++ b/released/packages/coq-metacoq/coq-metacoq.1.1+8.15/opam
@@ -42,5 +42,5 @@ See individual packages for more detailed descriptions.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1-8.15/metacoq-1.1-8.15.tar.gz"
-  checksum: "sha512=ebb88e267033fc6167f41d51ccb233c171eb70775ba3b04aa3c7517ff073be31dcdf331e9901897d6c3e5893f6d12ec48d5851d44c23b1ec8c7e7d3d505eb360"
+  checksum: "sha512=12ea0aff460c7eee07b5341ebcbf231c0f8aed9346842ad53c2244ab5ed865a0ecf6764116fbb26ecd3558f3de29c6054b8769d0c084b6d291a6b0e9a751c69a"
 }

--- a/released/packages/coq-metacoq/coq-metacoq.1.1+8.16/opam
+++ b/released/packages/coq-metacoq/coq-metacoq.1.1+8.16/opam
@@ -42,5 +42,5 @@ See individual packages for more detailed descriptions.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1-8.16/metacoq-1.1-8.16.tar.gz"
-  checksum: "sha512=aa984b616d5e91a264e765973ef02d8c180da282d7c87017fc2ca7f783ed819f0f62f5f96c1cab7f11fc2993cbb424f48c4a00a0bcdf0c98f19460cd7dcce5aa"
+  checksum: "sha512=89e9c6a2aaaf0512d981c1e2272bafc0a20a226a1e8834bf67a1054906f28aa1ce343da725e5e74e929d83c8685cd5222c879d6e6eb19124b26d3a3aea70d811"
 }

--- a/released/packages/coq-metacoq/coq-metacoq.1.1.1+8.14/opam
+++ b/released/packages/coq-metacoq/coq-metacoq.1.1.1+8.14/opam
@@ -42,5 +42,5 @@ See individual packages for more detailed descriptions.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1.1-8.14/metacoq-1.1.1-8.14.tar.gz"
-  checksum: "sha512=e54a9dc6a01dbe7c95343327e63eed8011366347bd02c29eca9426a6b8d955e5d0209df448e2f2fbb517e8b928f7d22276e55aae092bd3c4e9f4ba11bcac85c5"
+  checksum: "sha512=f9918b1cbe14b63350fad399ec8201c76c4e7af9082a39928f54285978ba21eba0e89a5e18f1a20fc867e41d80416863402a4de972b30aaf2627548fb27d4268"
 }

--- a/released/packages/coq-metacoq/coq-metacoq.1.1.1+8.15/opam
+++ b/released/packages/coq-metacoq/coq-metacoq.1.1.1+8.15/opam
@@ -42,5 +42,5 @@ See individual packages for more detailed descriptions.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1.1-8.15/metacoq-1.1.1-8.15.tar.gz"
-  checksum: "sha512=651f6f59cae604169a8c2fef48df75324791adf1becd881b36f01c5bc407a6fef9209d69f4c917d72e8c86f06ae2db976cfed6778be438786b14ab6daf771c25"
+  checksum: "sha512=05372e6e0d82fb7dd0bc2f3088aa6828b54f4c835526d52514f1d71d5d49b79a4506844de4a539bc951d7eb71f268e1f753a832e4ae4669f871c3b2323357ca0"
 }

--- a/released/packages/coq-metacoq/coq-metacoq.1.1.1+8.16/opam
+++ b/released/packages/coq-metacoq/coq-metacoq.1.1.1+8.16/opam
@@ -42,5 +42,5 @@ See individual packages for more detailed descriptions.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.1.1-8.16/metacoq-1.1.1-8.16.tar.gz"
-  checksum: "sha512=babae48068b31833a695ddbf7cac1043ccab778dcb5ea1cd6db3277f77f994a926636b10e58254615c88d080f69fc1885ea11d5bc8743e313e621aab2c9e48db"
+  checksum: "sha512=778e5cc64d35b782559fb245853444b2f87b4b3580acc62921251f8dfebf11e2be81ad1f37bdc26421faf7fc2678478028c097cc0afa61e5574b3072d5288917"
 }

--- a/released/packages/coq-metacoq/coq-metacoq.1.2+8.16/opam
+++ b/released/packages/coq-metacoq/coq-metacoq.1.2+8.16/opam
@@ -42,5 +42,5 @@ See individual packages for more detailed descriptions.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2-8.16/metacoq-1.2-8.16.tar.gz"
-  checksum: "sha512=80739c1424f5c28afadfcc581fa7016bc26f28f3a8b79597abc52ba5cc404cbe3728cccb260ab5ff7ed71ecb9a66690bcaa8d9cc6c0b79d2d1b5e660c34d5008"
+  checksum: "sha512=ff42d9391a01c2cd37f98766cb430c2740161f3dc34c7588e471476b05293b5eb7d4e392c3b42e9f24604edfe251d403516047188012beca90d8f3601898d6af"
 }

--- a/released/packages/coq-metacoq/coq-metacoq.1.2+8.17/opam
+++ b/released/packages/coq-metacoq/coq-metacoq.1.2+8.17/opam
@@ -42,5 +42,5 @@ See individual packages for more detailed descriptions.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2-8.17/metacoq-1.2-8.17.tar.gz"
-  checksum: "sha512=ef36dfe0e7864c67e223484f400f38531b41059c6e6e206a329b4dfa2c29e36ee133a711656fec3edcb37b046e5602d1a81c9989c399729f4547f19e854ccdbd"
+  checksum: "sha512=17add66108aadc1f8d9d513c92c94e94265cd10ad73d7999dd0ee2e53666094af7ec8aa9d93f089389576f2efc5fb4b23faad663319f814fbbc73aaf8e2bf999"
 }

--- a/released/packages/coq-metacoq/coq-metacoq.1.2.1+8.17/opam
+++ b/released/packages/coq-metacoq/coq-metacoq.1.2.1+8.17/opam
@@ -42,5 +42,5 @@ See individual packages for more detailed descriptions.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2.1-8.17/metacoq-1.2.1-8.17.tar.gz"
-  checksum: "sha512=c02f106aafa1082bb6c2be5bb1c972840cd23d94c85541996767855e1a3080bc00405f463d275285847385680aa69b3798d067ed73e4712d8a137024cc256cab"
+  checksum: "sha512=c19536c0907711c28287844dcc469cb61ebda02c154c62174419b41fffc72ea58f8ac5a84711c6273b68b1d01f20741cc5c762501eddb8a1185befb6c4d15294"
 }

--- a/released/packages/coq-metacoq/coq-metacoq.1.2.1+8.18/opam
+++ b/released/packages/coq-metacoq/coq-metacoq.1.2.1+8.18/opam
@@ -42,5 +42,5 @@ See individual packages for more detailed descriptions.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.2.1-8.18/metacoq-1.2.1-8.18.tar.gz"
-  checksum: "sha512=3b2a6c1cb8005a7f675c47209b17f0b3f2ded6b3ae324f6a6782f0b23e5e5e5e25ac1d1c8a97be1c9b89b4490dda80567a3f57c254314a185a01ca9f0fc94d82"
+  checksum: "sha512=0ad6a8777807d744ceb330e05989880422f6e2afa462571bff4e2d97b55ed7a0987998192e4ce289472b81112731bfdba0379b52e810fbe0851cc61a0e29b29e"
 }

--- a/released/packages/coq-metacoq/coq-metacoq.1.3+8.17/opam
+++ b/released/packages/coq-metacoq/coq-metacoq.1.3+8.17/opam
@@ -42,5 +42,5 @@ See individual packages for more detailed descriptions.
 """
 url {
   src: "https://github.com/MetaRocq/metarocq/releases/download/v1.3-8.17/metacoq-1.3-8.17.tar.gz"
-  checksum: "sha512=eef100ec9a30031d99e8f626f00fbd4d3156bc64e440086876c13490207e6fd845cf9c0688dc417feb4f4acd1c9ca7f3d467dd3250319090250c926e7c62fba0"
+  checksum: "sha512=ff4ed8a4cf33afb2a93c8ec07f00327f9924e82c81cb82ca74e0fe81b2199d5b13716fe5224fc0998952936c59ff0f52ed79703641745114a2ac777ab86beeb4"
 }

--- a/released/packages/coq-metacoq/coq-metacoq.1.3.4+8.20/opam
+++ b/released/packages/coq-metacoq/coq-metacoq.1.3.4+8.20/opam
@@ -41,6 +41,6 @@ a safe type checker and verified erasure for PCUIC and example translations.
 See individual packages for more detailed descriptions.
 """
 url {
-  src: "https://github.com/MetaCoq/metacoq/archive/refs/tags/v1.3.4-8.20.tar.gz"
-  checksum: "sha512=fb3997e2e07e9c33c293aabcc06b8e69785a9c2ebdcd4d48f77e1eb09698da6ed1770127022843f89322cf8f78289acd67c860e1a2d9186d5703191ccd088429"
+  src: "https://github.com/MetaRocq/metarocq/releases/download/v1.3.4-8.20/metacoq-1.3.4-8.20.tar.gz"
+  checksum: "sha512=82d2a0cf514dce221557a3f63d024a1a020a8a6b20de7e859d1df3f58266ae432122545602a5a382ba4c21161e976c4cc0aa0b2601ee5a838b287883ebabc75a"
 }


### PR DESCRIPTION
The archives were previously broken due to use of MacOS's `tar` utility secretely adding some files at the root (and everywhere else). Fixed by using the GNU tar program instead, updating the releases tarballs and hence updating the hashes here. I tested locally the checksum correctness, metacoq-utils compiles for 1.0+8.16 and 1.3.4+8.20.