### PR TITLE
 added dev version for coq-htt and coq-htt-core

### DIFF
--- a/extra-dev/packages/coq-htt-core/coq-htt-core.dev/opam
+++ b/extra-dev/packages/coq-htt-core/coq-htt-core.dev/opam
@@ -53,7 +53,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/imdea-software/htt.git#master"
-  checksum: "sha256=e2819211c05a011f8101d006865c642a513c3e581810f590d8d8d7a651046b05"
+  src: "git+https://github.com/imdea-software/htt.git#master"
 }
 

--- a/extra-dev/packages/coq-htt-core/coq-htt-core.dev/opam
+++ b/extra-dev/packages/coq-htt-core/coq-htt-core.dev/opam
@@ -27,15 +27,15 @@ variables). The connection reconciles dependent types with effects of state and 
 establishes Separation logic as a type theory for such effects. In implementation terms, it means
 that HTT implements Separation logic as a shallow embedding in Coq."""
 
-build: [make "-C" "examples" "-j%{jobs}%"]
-install: [make "-C" "examples" "install"]
+build: [make "-C" "htt" "-j%{jobs}%"]
+install: [make "-C" "htt" "install"]
 depends: [
-  "coq" {>= "8.19" & < "9.1~"}
-  "coq-mathcomp-ssreflect" {>= "2.2.0" & < "2.4~"}
+  "coq" {>= "8.19"}
+  "coq-mathcomp-ssreflect" {>= "2.2.0"}
+  "coq-hierarchy-builder" {>= "1.7.0"}
   "coq-mathcomp-algebra" 
   "coq-mathcomp-fingroup" 
-  "coq-fcsl-pcm" {>= "2.1.0" & < "2.2~"}
-  "coq-htt-core" {= version}
+  "coq-fcsl-pcm" {>= "2.1.0"}
 ]
 
 tags: [
@@ -53,7 +53,7 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/imdea-software/htt/archive/refs/tags/v2.1.0.tar.gz"
+  src: "https://github.com/imdea-software/htt.git#master"
   checksum: "sha256=e2819211c05a011f8101d006865c642a513c3e581810f590d8d8d7a651046b05"
 }
 

--- a/extra-dev/packages/coq-htt/coq-htt.dev/opam
+++ b/extra-dev/packages/coq-htt/coq-htt.dev/opam
@@ -54,7 +54,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/imdea-software/htt.git#master"
-  checksum: "sha256=e2819211c05a011f8101d006865c642a513c3e581810f590d8d8d7a651046b05"
+  src: "git+https://github.com/imdea-software/htt.git#master"
 }
 

--- a/extra-dev/packages/coq-htt/coq-htt.dev/opam
+++ b/extra-dev/packages/coq-htt/coq-htt.dev/opam
@@ -30,11 +30,12 @@ that HTT implements Separation logic as a shallow embedding in Coq."""
 build: [make "-C" "examples" "-j%{jobs}%"]
 install: [make "-C" "examples" "install"]
 depends: [
-  "coq" {>= "8.19" & < "9.1~"}
-  "coq-mathcomp-ssreflect" {>= "2.2.0" & < "2.4~"}
+  "coq" {>= "8.19"}
+  "coq-mathcomp-ssreflect" {>= "2.2.0"}
+  "coq-hierarchy-builder" {>= "1.7.0"}
   "coq-mathcomp-algebra" 
   "coq-mathcomp-fingroup" 
-  "coq-fcsl-pcm" {>= "2.1.0" & < "2.2~"}
+  "coq-fcsl-pcm" {>= "2.1.0"}
   "coq-htt-core" {= version}
 ]
 
@@ -53,7 +54,7 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/imdea-software/htt/archive/refs/tags/v2.1.0.tar.gz"
+  src: "https://github.com/imdea-software/htt.git#master"
   checksum: "sha256=e2819211c05a011f8101d006865c642a513c3e581810f590d8d8d7a651046b05"
 }
 

--- a/released/packages/coq-fcsl-pcm/coq-fcsl-pcm.2.1.0/opam
+++ b/released/packages/coq-fcsl-pcm/coq-fcsl-pcm.2.1.0/opam
@@ -21,9 +21,9 @@ This library relies on propositional and functional extentionality axioms."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" { (>= "8.19" & < "9.1~") | (= "dev") }
-  "coq-mathcomp-ssreflect" { (>= "2.2.0" & < "2.4~") | (= "dev") }
-  "coq-hierarchy-builder" { (>= "1.7.0" & < "1.9~") | (= "dev") }
+  "coq" {>= "8.19" & < "9.1~"}
+  "coq-mathcomp-ssreflect" {>= "2.2.0" & < "2.4~"}
+  "coq-hierarchy-builder" {>= "1.7.0" & < "1.9~"}
   "coq-mathcomp-algebra" 
 ]
 

--- a/released/packages/coq-htt-core/coq-htt-core.2.1.0/opam
+++ b/released/packages/coq-htt-core/coq-htt-core.2.1.0/opam
@@ -30,11 +30,11 @@ that HTT implements Separation logic as a shallow embedding in Coq."""
 build: [make "-C" "htt" "-j%{jobs}%"]
 install: [make "-C" "htt" "install"]
 depends: [
-  "coq" { (>= "8.19" & < "9.1~") | (= "dev") }
-  "coq-mathcomp-ssreflect" { (>= "2.2.0" & < "2.4~") | (= "dev") }
+  "coq" {>= "8.19" & < "9.1~"}
+  "coq-mathcomp-ssreflect" {>= "2.2.0" & < "2.4~"}
   "coq-mathcomp-algebra" 
   "coq-mathcomp-fingroup" 
-  "coq-fcsl-pcm" { (>= "2.1.0" & < "2.2~") | (= "dev") }
+  "coq-fcsl-pcm" {>= "2.1.0" & < "2.2~"}
 ]
 
 tags: [


### PR DESCRIPTION
[added dev version for coq-htt and coq-htt-core 
removed dev from coq-fcsl-pcm/coq-htt/coq-htt-core v2.1.0](https://github.com/rocq-prover/opam/pull/3382)