### PR TITLE
update mathcomp packages to version 2.4.0

### DIFF
--- a/released/packages/coq-mathcomp-algebra/coq-mathcomp-algebra.2.4.0/opam
+++ b/released/packages/coq-mathcomp-algebra/coq-mathcomp-algebra.2.4.0/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+
+homepage: "https://math-comp.github.io/"
+bug-reports: "https://github.com/math-comp/math-comp/issues"
+dev-repo: "git+https://github.com/math-comp/math-comp.git"
+license: "CECILL-B"
+
+depends: [ "coq-core" "rocq-mathcomp-algebra" { = version } ]
+authors: [ "The Mathematical Components team" ]
+
+synopsis: "Compatibility package for rocq-mathcomp-algebra"
+
+url {
+src: "https://github.com/math-comp/math-comp/archive/mathcomp-2.4.0.tar.gz"
+checksum: "sha256=6307218d7e434fb6ffc81b9275c673d3f7f1f4884ad59b904abd205c437021a0"
+}

--- a/released/packages/coq-mathcomp-character/coq-mathcomp-character.2.4.0/opam
+++ b/released/packages/coq-mathcomp-character/coq-mathcomp-character.2.4.0/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+
+homepage: "https://math-comp.github.io/"
+bug-reports: "https://github.com/math-comp/math-comp/issues"
+dev-repo: "git+https://github.com/math-comp/math-comp.git"
+license: "CECILL-B"
+
+depends: [ "coq-core" "rocq-mathcomp-character" { = version } ]
+authors: [ "The Mathematical Components team" ]
+
+synopsis: "Compatibility package for rocq-mathcomp-character"
+
+url {
+src: "https://github.com/math-comp/math-comp/archive/mathcomp-2.4.0.tar.gz"
+checksum: "sha256=6307218d7e434fb6ffc81b9275c673d3f7f1f4884ad59b904abd205c437021a0"
+}

--- a/released/packages/coq-mathcomp-field/coq-mathcomp-field.2.4.0/opam
+++ b/released/packages/coq-mathcomp-field/coq-mathcomp-field.2.4.0/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+
+homepage: "https://math-comp.github.io/"
+bug-reports: "https://github.com/math-comp/math-comp/issues"
+dev-repo: "git+https://github.com/math-comp/math-comp.git"
+license: "CECILL-B"
+
+depends: [ "coq-core" "rocq-mathcomp-field" { = version } ]
+authors: [ "The Mathematical Components team" ]
+
+synopsis: "Compatibility package for rocq-mathcomp-field"
+
+url {
+src: "https://github.com/math-comp/math-comp/archive/mathcomp-2.4.0.tar.gz"
+checksum: "sha256=6307218d7e434fb6ffc81b9275c673d3f7f1f4884ad59b904abd205c437021a0"
+}

--- a/released/packages/coq-mathcomp-fingroup/coq-mathcomp-fingroup.2.4.0/opam
+++ b/released/packages/coq-mathcomp-fingroup/coq-mathcomp-fingroup.2.4.0/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+
+homepage: "https://math-comp.github.io/"
+bug-reports: "https://github.com/math-comp/math-comp/issues"
+dev-repo: "git+https://github.com/math-comp/math-comp.git"
+license: "CECILL-B"
+
+depends: [ "coq-core" "rocq-mathcomp-fingroup" {= version} ]
+authors: [ "The Mathematical Components team" ]
+
+synopsis: "Compatibility package for rocq-mathcomp-fingroup"
+
+url {
+src: "https://github.com/math-comp/math-comp/archive/mathcomp-2.4.0.tar.gz"
+checksum: "sha256=6307218d7e434fb6ffc81b9275c673d3f7f1f4884ad59b904abd205c437021a0"
+}

--- a/released/packages/coq-mathcomp-solvable/coq-mathcomp-solvable.2.4.0/opam
+++ b/released/packages/coq-mathcomp-solvable/coq-mathcomp-solvable.2.4.0/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+
+homepage: "https://math-comp.github.io/"
+bug-reports: "https://github.com/math-comp/math-comp/issues"
+dev-repo: "git+https://github.com/math-comp/math-comp.git"
+license: "CECILL-B"
+
+depends: [ "coq-core" "rocq-mathcomp-solvable" { = version } ]
+authors: [ "The Mathematical Components team" ]
+
+synopsis: "Compatibility package for rocq-mathcomp-solvable"
+
+url {
+src: "https://github.com/math-comp/math-comp/archive/mathcomp-2.4.0.tar.gz"
+checksum: "sha256=6307218d7e434fb6ffc81b9275c673d3f7f1f4884ad59b904abd205c437021a0"
+}

--- a/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.2.4.0/opam
+++ b/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.2.4.0/opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+
+homepage: "https://math-comp.github.io/"
+bug-reports: "https://github.com/math-comp/math-comp/issues"
+dev-repo: "git+https://github.com/math-comp/math-comp.git"
+license: "CECILL-B"
+
+depends: [
+  "coq-core"
+  "rocq-mathcomp-ssreflect" {= version}
+]
+authors: [ "The Mathematical Components team" ]
+
+synopsis: "Compatibility package for rocq-mathcomp-ssreflect"
+
+url {
+src: "https://github.com/math-comp/math-comp/archive/mathcomp-2.4.0.tar.gz"
+checksum: "sha256=6307218d7e434fb6ffc81b9275c673d3f7f1f4884ad59b904abd205c437021a0"
+}

--- a/released/packages/rocq-mathcomp-algebra/rocq-mathcomp-algebra.2.4.0/opam
+++ b/released/packages/rocq-mathcomp-algebra/rocq-mathcomp-algebra.2.4.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+
+homepage: "https://math-comp.github.io/"
+bug-reports: "https://github.com/math-comp/math-comp/issues"
+dev-repo: "git+https://github.com/math-comp/math-comp.git"
+license: "CECILL-B"
+
+build: [ make "-C" "algebra" "-j" "%{jobs}%" ]
+install: [ make "-C" "algebra" "install" ]
+depends: [ "rocq-mathcomp-fingroup" { = version } ]
+
+tags: [
+  "keyword:small scale reflection"
+  "keyword:mathematical components"
+  "keyword:algebra"
+  "keyword:algebraic structure hierarchies"
+  "keyword:archimedean field"
+  "keyword:floor"
+  "keyword:ceil"
+  "keyword:intervals"
+  "keyword:matrices"
+  "keyword:vectors"
+  "keyword:block matrices"
+  "keyword:determinant"
+  "keyword:Cramer rule"
+  "keyword:Vandermonde matrices"
+  "keyword:LUP decomposition"
+  "keyword:Gaussian elimination"
+  "keyword:matrix rank"
+  "keyword:eigen values"
+  "keyword:single variable polynomials"
+  "keyword:bivariate polynomials"
+  "keyword:polynomial division"
+  "keyword:integers"
+  "keyword:rational numbers"
+  "keyword:semirings"
+  "keyword:rings"
+  "keyword:left algebra"
+  "keyword:left module"
+  "keyword:unit rings"
+  "keyword:field"
+  "keyword:algebraically closed field"
+  "keyword:additive morphisms"
+  "keyword:ring morphisms"
+  "keyword:finite dimensional vector spaces"
+  "keyword:complex numbers"
+  "keyword:square root"
+  "logpath:mathcomp.algebra"
+]
+authors: [ "The Mathematical Components team" ]
+
+synopsis: "Mathematical Components Library on Algebra"
+description: """
+This library contains definitions and theorems about discrete
+(i.e. with decidable equality) algebraic structures : ring, fields,
+ordered fields, real fields,  modules, algebras, integers, rational
+numbers, polynomials, matrices, vector spaces...
+"""
+
+url {
+src: "https://github.com/math-comp/math-comp/archive/mathcomp-2.4.0.tar.gz"
+checksum: "sha256=6307218d7e434fb6ffc81b9275c673d3f7f1f4884ad59b904abd205c437021a0"
+}

--- a/released/packages/rocq-mathcomp-character/rocq-mathcomp-character.2.4.0/opam
+++ b/released/packages/rocq-mathcomp-character/rocq-mathcomp-character.2.4.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+
+homepage: "https://math-comp.github.io/"
+bug-reports: "https://github.com/math-comp/math-comp/issues"
+dev-repo: "git+https://github.com/math-comp/math-comp.git"
+license: "CECILL-B"
+
+build: [ make "-C" "character" "-j" "%{jobs}%" ]
+install: [ make "-C" "character" "install" ]
+depends: [ "rocq-mathcomp-field" { = version } ]
+
+tags: [
+  "keyword:small scale reflection"
+  "keyword:mathematical components"
+  "keyword:algebra"
+  "keyword:character"
+  "logpath:mathcomp.character"
+]
+authors: [ "The Mathematical Components team" ]
+
+synopsis: "Mathematical Components Library on character theory"
+description:"""
+This library contains definitions and theorems about group
+representations, characters and class functions.
+"""
+
+url {
+src: "https://github.com/math-comp/math-comp/archive/mathcomp-2.4.0.tar.gz"
+checksum: "sha256=6307218d7e434fb6ffc81b9275c673d3f7f1f4884ad59b904abd205c437021a0"
+}

--- a/released/packages/rocq-mathcomp-field/rocq-mathcomp-field.2.4.0/opam
+++ b/released/packages/rocq-mathcomp-field/rocq-mathcomp-field.2.4.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+
+homepage: "https://math-comp.github.io/"
+bug-reports: "https://github.com/math-comp/math-comp/issues"
+dev-repo: "git+https://github.com/math-comp/math-comp.git"
+license: "CECILL-B"
+
+build: [ make "-C" "field" "-j" "%{jobs}%" ]
+install: [ make "-C" "field" "install" ]
+depends: [ "rocq-mathcomp-solvable" { = version } ]
+
+tags: [
+  "keyword:small scale reflection"
+  "keyword:mathematical components"
+  "keyword:algebra"
+  "keyword:field"
+  "logpath:mathcomp.field"
+]
+authors: [ "The Mathematical Components team" ]
+
+synopsis: "Mathematical Components Library on Fields"
+description:"""
+This library contains definitions and theorems about field extensions,
+galois theory, algebraic numbers, cyclotomic polynomials...
+"""
+
+url {
+src: "https://github.com/math-comp/math-comp/archive/mathcomp-2.4.0.tar.gz"
+checksum: "sha256=6307218d7e434fb6ffc81b9275c673d3f7f1f4884ad59b904abd205c437021a0"
+}

--- a/released/packages/rocq-mathcomp-fingroup/rocq-mathcomp-fingroup.2.4.0/opam
+++ b/released/packages/rocq-mathcomp-fingroup/rocq-mathcomp-fingroup.2.4.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+
+homepage: "https://math-comp.github.io/"
+bug-reports: "https://github.com/math-comp/math-comp/issues"
+dev-repo: "git+https://github.com/math-comp/math-comp.git"
+license: "CECILL-B"
+
+build: [ make "-C" "fingroup" "-j" "%{jobs}%" ]
+install: [ make "-C" "fingroup" "install" ]
+depends: [ "rocq-mathcomp-ssreflect" { = version } ]
+
+tags: [
+  "keyword:small scale reflection"
+  "keyword:mathematical components"
+  "keyword:finite groups"
+  "logpath:mathcomp.fingroup"
+]
+authors: [ "The Mathematical Components team" ]
+
+synopsis: "Mathematical Components Library on finite groups"
+description: """
+This library contains definitions and theorems about finite groups,
+group quotients, group morphisms, group presentation, group action...
+"""
+
+url {
+src: "https://github.com/math-comp/math-comp/archive/mathcomp-2.4.0.tar.gz"
+checksum: "sha256=6307218d7e434fb6ffc81b9275c673d3f7f1f4884ad59b904abd205c437021a0"
+}

--- a/released/packages/rocq-mathcomp-solvable/rocq-mathcomp-solvable.2.4.0/opam
+++ b/released/packages/rocq-mathcomp-solvable/rocq-mathcomp-solvable.2.4.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+
+homepage: "https://math-comp.github.io/"
+bug-reports: "https://github.com/math-comp/math-comp/issues"
+dev-repo: "git+https://github.com/math-comp/math-comp.git"
+license: "CECILL-B"
+
+build: [ make "-C" "solvable" "-j" "%{jobs}%" ]
+install: [ make "-C" "solvable"  "install" ]
+depends: [ "rocq-mathcomp-algebra" { = version } ]
+
+tags: [
+  "keyword:small scale reflection"
+  "keyword:mathematical components"
+  "keyword:finite groups"
+  "logpath:mathcomp.solvable"
+]
+authors: [ "The Mathematical Components team" ]
+
+synopsis: "Mathematical Components Library on finite groups (II)"
+
+description:"""
+This library contains more definitions and theorems about finite groups.
+"""
+
+url {
+src: "https://github.com/math-comp/math-comp/archive/mathcomp-2.4.0.tar.gz"
+checksum: "sha256=6307218d7e434fb6ffc81b9275c673d3f7f1f4884ad59b904abd205c437021a0"
+}

--- a/released/packages/rocq-mathcomp-ssreflect/rocq-mathcomp-ssreflect.2.4.0/opam
+++ b/released/packages/rocq-mathcomp-ssreflect/rocq-mathcomp-ssreflect.2.4.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+
+homepage: "https://math-comp.github.io/"
+bug-reports: "https://github.com/math-comp/math-comp/issues"
+dev-repo: "git+https://github.com/math-comp/math-comp.git"
+license: "CECILL-B"
+
+build: [ make "-C" "ssreflect" "-j" "%{jobs}%" ]
+install: [ make "-C" "ssreflect" "install" ]
+depends: [
+  ("coq" {>= "8.19" & < "8.21~"}
+  | "rocq-core" {(>= "9.0" & < "9.1~") | = "dev"})
+  # Please keep the "dev" above as it is required for the coq-dev Docker images
+  "elpi" {>= "1.17.0"}
+  "coq-hierarchy-builder" { >= "1.7.0"}
+]
+conflicts: [ "coq-mathcomp-ssreflect" {< "2.4~"} ]
+
+tags: [
+  "keyword:small scale reflection"
+  "keyword:mathematical components"
+  "keyword:bigop"
+  "keyword:big operators"
+  "keyword:biomial coefficient"
+  "keyword:integer division theory"
+  "keyword:finite sets"
+  "keyword:functions with finite domain"
+  "keyword:finite graphs"
+  "keyword:quotient types"
+  "keyword:order theory"
+  "keyword:partial order"
+  "keyword:lattices"
+  "keyword:lists"
+  "keyword:ordering and sorting lists"
+  "keyword:prime numbers"
+  "keyword:tuples"
+  "keyword:bounded lists"
+  "logpath:mathcomp.ssreflect"
+]
+authors: [ "The Mathematical Components team" ]
+
+synopsis: "Small Scale Reflection"
+description: """
+This library includes the small scale reflection proof language
+extension and the minimal set of libraries to take advantage of it.
+This includes libraries on lists (seq), boolean and boolean
+predicates, natural numbers and types with decidable equality,
+finite types, finite sets, finite functions, finite graphs, basic arithmetics
+and prime numbers, big operators
+"""
+
+url {
+src: "https://github.com/math-comp/math-comp/archive/mathcomp-2.4.0.tar.gz"
+checksum: "sha256=6307218d7e434fb6ffc81b9275c673d3f7f1f4884ad59b904abd205c437021a0"
+}


### PR DESCRIPTION
ci-skip: coq-mathcomp-ssreflect.2.4.0 coq-mathcomp-fingroup.2.4.0 coq-mathcomp-algebra.1.19.0 coq-mathcomp-solvable.2.4.0 coq-mathcomp-field.2.4.0