### PR TITLE
updating finmap dependencies

### DIFF
--- a/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.2.1.0/opam
+++ b/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.2.1.0/opam
@@ -17,8 +17,9 @@ which will be used to subsume notations for finite sets, eventually."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" { (>= "8.16" & < "9.1~") | (= "dev") }
-  "coq-mathcomp-ssreflect" { (>= "2.0.0" & < "2.4~") | (= "dev") }
+  ("coq" {>= "8.20" & < "8.21~"}
+  | "rocq-core" {>= "9.0" | = "dev"})
+  "coq-mathcomp-ssreflect" { (>= "2.0" & < "2.5~") | = "dev" }
 ]
 
 tags: [


### PR DESCRIPTION
This updates the dependencies of the `finmap` package to add compatibility to `math-comp` 2.4.0. It also removes the dependency on `stdlib` if Rocq is installed.