### PR TITLE
make fourcolor (fourcolor-reals) work with rocq 9

### DIFF
--- a/released/packages/coq-fourcolor-reals/coq-fourcolor-reals.1.4.0/opam
+++ b/released/packages/coq-fourcolor-reals/coq-fourcolor-reals.1.4.0/opam
@@ -14,8 +14,9 @@ with proofs of properties such as categoricity."""
 build: [make "-C" "theories/reals" "-j%{jobs}%"]
 install: [make "-C" "theories/reals" "install"]
 depends: [
-  "coq" {(>= "8.16" & < "8.21~") | (= "dev")}
-  "coq-mathcomp-ssreflect" {(>= "2.1.0" & < "2.4~") | (= "dev")}
+  ("coq" {>= "8.16" & < "8.21~"} |
+   "rocq-core"{ (>= "9.0" & < "9.1~") | (= "dev")0})
+  "coq-mathcomp-ssreflect" {(>= "2.1.0" & < "2.5~") | (= "dev")}
   "coq-mathcomp-algebra" 
 ]
 

--- a/released/packages/coq-fourcolor/coq-fourcolor.1.4.0/opam
+++ b/released/packages/coq-fourcolor/coq-fourcolor.1.4.0/opam
@@ -16,8 +16,9 @@ basic plane topology definitions, and a theory of combinatorial hypermaps."""
 build: [make "-C" "theories/proof" "-j%{jobs}%"]
 install: [make "-C" "theories/proof" "install"]
 depends: [
-  "coq" {(>= "8.16" & < "9.1~") | (= "dev")}
-  "coq-mathcomp-ssreflect" {(>= "2.1.0" & < "2.4~") | (= "dev")}
+  ("coq" {>= "8.16" & < "9.1~"} |
+   "rocq-core" { ( >= "9.0" & "9.1~") | (= "dev") })
+  "coq-mathcomp-ssreflect" {(>= "2.1.0" & < "2.5~") | (= "dev")}
   "coq-mathcomp-algebra"
   "coq-hierarchy-builder" {>= "1.5.0"}
   "coq-fourcolor-reals" {= version}


### PR DESCRIPTION
Only modifications were inspired by @proux01's changes in opam files of the community development.  Compilation was tested on my machine, and showed compatibility with the 2.4.0 release of math-comp.