### PR TITLE
Update ssreflect bound on mathcomp-word 3.2 package

### DIFF
--- a/released/packages/coq-mathcomp-word/coq-mathcomp-word.3.2/opam
+++ b/released/packages/coq-mathcomp-word/coq-mathcomp-word.3.2/opam
@@ -12,7 +12,7 @@ build: [ "dune" "build" "-p" name "-j" jobs ]
 depends: [
   "dune" {>= "2.8"}
   "coq" {>= "8.16"}
-  "coq-mathcomp-ssreflect" {>= "2.0" & < "2.4~"}
+  "coq-mathcomp-ssreflect" {>= "2.0" & < "2.5~"}
   "coq-mathcomp-algebra"
 ]
 tags: [


### PR DESCRIPTION
coq-mathcomp-word 3.2 builds with math-comp 2.4.0