### PR TITLE
Fix rocq-hierarchy-builder dependency

### DIFF
--- a/released/packages/rocq-hierarchy-builder/rocq-hierarchy-builder.1.9.0/opam
+++ b/released/packages/rocq-hierarchy-builder/rocq-hierarchy-builder.1.9.0/opam
@@ -13,7 +13,7 @@ install: [ make "install" ]
 depends: [
   ("coq" {>= "8.18" & < "8.20~"} & "coq-elpi" {>= "2.0"}
   | "coq" {>= "8.20" & < "8.21~"} & "coq-elpi" {>= "2.4" | = "dev"}
-  | "rocq-core" {(>= "9.0" & < "9.1~") | = "dev"} & "coq-elpi" {>= "2.4" | = "dev"})
+  | "rocq-core" {(>= "9.0" & < "9.1~") | = "dev"} & "rocq-elpi" {>= "2.4" | = "dev"})
 ]
 conflicts: [
   "coq-hierarchy-builder" {< "1.9~"}


### PR DESCRIPTION
As noted in https://github.com/rocq-prover/opam/pull/3396#discussion_r2053740780