### PR TITLE
no dep on rocq-core for MathComp-Analysis

### DIFF
--- a/released/packages/coq-mathcomp-classical/coq-mathcomp-classical.1.10.0/opam
+++ b/released/packages/coq-mathcomp-classical/coq-mathcomp-classical.1.10.0/opam
@@ -14,8 +14,7 @@ the Coq proof-assistant and using the Mathematical Components library."""
 build: [make "-C" "classical" "-j%{jobs}%"]
 install: [make "-C" "classical" "install"]
 depends: [
-  ("coq" {>= "8.19" & < "8.21~"}
-  | "rocq-core" { (>= "9.0" & < "9.1~") | (= "dev") })
+  "coq" { (>= "8.19" & < "9.1~") | (= "dev") }
   "coq-mathcomp-ssreflect" { (>= "2.1.0") }
   "coq-mathcomp-fingroup"
   "coq-mathcomp-algebra"

--- a/released/packages/coq-mathcomp-reals-stdlib/coq-mathcomp-reals-stdlib.1.10.0/opam
+++ b/released/packages/coq-mathcomp-reals-stdlib/coq-mathcomp-reals-stdlib.1.10.0/opam
@@ -14,8 +14,7 @@ the Coq proof-assistant using the Mathematical Components library and Stdlib."""
 build: [make "-C" "reals_stdlib" "-j%{jobs}%"]
 install: [make "-C" "reals_stdlib" "install"]
 depends: [
-  ("coq" {< "8.21~"}
-  | "rocq-stdlib" { (>= "9.0" & < "9.1~") | (= "dev") })
+  "coq" { (>= "8.19" & < "9.1~") | (= "dev") }
   "coq-mathcomp-reals" { = version}
 ]
 


### PR DESCRIPTION
ci-skip: coq-mathcomp-classical coq-mathcomp-reals coq-mathcomp-analysis coq-mathcomp-reals-stdlib