### PR TITLE
Release 2.2.0 finmap

### DIFF
--- a/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.finmap/opam
+++ b/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.finmap/opam
@@ -1,0 +1,42 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "Cyril Cohen <cyril.cohen@inria.fr>"
+
+homepage: "https://github.com/math-comp/finmap"
+dev-repo: "git+https://github.com/math-comp/finmap.git"
+bug-reports: "https://github.com/math-comp/finmap/issues"
+license: "CECILL-B"
+
+synopsis: "Finite sets, finite maps, finitely supported functions"
+description: """
+This library is an extension of mathematical component in order to
+support finite sets and finite maps on choicetypes (rather that finite
+types). This includes support for functions with finite support and
+multisets. The library also contains a generic order and set libary,
+which will be used to subsume notations for finite sets, eventually."""
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+depends: [
+  ("coq" {>= "8.20" & < "8.21~"}
+  | "rocq-core" {>= "9.0" | = "dev"})
+  "coq-mathcomp-ssreflect" { (>= "2.0" & < "2.5~") | = "dev" }
+]
+
+tags: [
+  "keyword:finmap"
+  "keyword:finset"
+  "keyword:multiset"
+  "logpath:mathcomp.finmap"
+]
+authors: [
+  "Cyril Cohen"
+  "Kazuhiko Sakaguchi"
+]
+
+url {
+  src: "https://github.com/math-comp/finmap/archive/refs/tags/2.2.0.tar.gz"
+  checksum: "sha256=8dbd1f2c9ce8c7736a6ce9701b791ec42d0eef6ad397db19eba3a831b38e4da2"
+}


### PR DESCRIPTION
Apologies @palmskog @silene @proux01, I had some confusion with version numbers.
This is my proposal to release finmap 2.2.0, so that also mathcomp-analysis and other projects can be made compatible with mathcomp 2.4.0 when fetched through opam.