### PR TITLE
Package rocq-navi.0.2.0

### DIFF
--- a/released/packages/rocq-navi/rocq-navi.0.2.0/opam
+++ b/released/packages/rocq-navi/rocq-navi.0.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Yoshihiro Imai<y.imai@aist.go.jp>"
+
+homepage: "https://github.com/affeldt-aist/rocqnavi"
+dev-repo: "git+https://github.com/yoshihiro503/rocqnavi.git"
+bug-reports: "https://github.com/affeldt-aist/rocqnavi/issues"
+
+license: "GPL-2.0-or-later"
+synopsis: "Extension of coq2html Document Generator"
+
+description: """
+Extension of coq2html Document Generator"""
+
+build: [make]
+install: [make "BINDIR=%{bin}%" "install"]
+depends: [
+  "ocaml" {>= "4.14"}
+]
+
+tags: [
+  "category:Tools/Document Generator"
+  "keyword:document"
+  "keyword:html"
+  "logpath:"
+]
+authors: [
+  "Xavier Leroy <xavier.leroy@college-de-france.fr>"
+  "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+  "Yoshihiro Imai <y.imai@aist.go.jp>"
+]
+
+url {
+  src:
+    "https://github.com/affeldt-aist/rocqnavi/archive/refs/tags/rocqnavi.0.2.0.tar.gz"
+  checksum: [
+    "md5=690c03b9adc411c6ebd3413890b3f630"
+    "sha512=6ffc14bf720f39bd5baf690fd1f3705eea30a588cbdf3adabdb8dee05eda0c59ae19e7b969a780ee4be500f92291e509eeb79b4d04f0fc6ef04c4f059a4c32b1"
+  ]
+}


### PR DESCRIPTION
### `rocq-navi.0.2.0`
Extension of coq2html Document Generator
Extension of coq2html Document Generator



---
* Homepage: https://github.com/affeldt-aist/rocqnavi
* Source repo: git+https://github.com/yoshihiro503/rocqnavi.git
* Bug tracker: https://github.com/affeldt-aist/rocqnavi/issues

---
:camel: Pull-request generated by opam-publish v2.5.0