### PR TITLE
Fix coq-mathcomp-finmap.2.2.0

### DIFF
--- a/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.2.2.0/opam
+++ b/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.2.2.0/opam
@@ -20,8 +20,7 @@ which will be used to subsume notations for finite sets, eventually."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  ("coq" {>= "8.20" & < "8.21~"}
-  | "rocq-core" {>= "9.0" | = "dev"})
+  "coq" { (>= "8.20" & < "9.1~") | = "dev"}
   "coq-mathcomp-ssreflect" { (>= "2.0" & < "2.5~") | = "dev" }
 ]
 


### PR DESCRIPTION
Fix finmap 2.2.0 wrong filename and dependency from https://github.com/rocq-prover/opam/pull/3405#issuecomment-2829609815

Cc @hoheinzollern @palmskog 