### PR TITLE
Add coq-hierarchy-builder.1.9.1

### DIFF
--- a/released/packages/coq-hierarchy-builder/coq-hierarchy-builder.1.9.1/opam
+++ b/released/packages/coq-hierarchy-builder/coq-hierarchy-builder.1.9.1/opam
@@ -1,0 +1,14 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Cyril Cohen" "Kazuhiko Sakaguchi" "Enrico Tassi" ]
+license: "MIT"
+homepage: "https://github.com/math-comp/hierarchy-builder"
+bug-reports: "https://github.com/math-comp/hierarchy-builder/issues"
+dev-repo: "git+https://github.com/math-comp/hierarchy-builder"
+
+depends: [
+  "coq-core"
+  "rocq-hierarchy-builder" {= version}
+]
+
+synopsis: "Compatibility package for rocq-hierarchy-builder"

--- a/released/packages/rocq-hierarchy-builder/rocq-hierarchy-builder.1.9.1/opam
+++ b/released/packages/rocq-hierarchy-builder/rocq-hierarchy-builder.1.9.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Cyril Cohen" "Kazuhiko Sakaguchi" "Enrico Tassi" ]
+license: "MIT"
+homepage: "https://github.com/math-comp/hierarchy-builder"
+bug-reports: "https://github.com/math-comp/hierarchy-builder/issues"
+dev-repo: "git+https://github.com/math-comp/hierarchy-builder"
+
+build: [ [ make "build"]
+         [ make "test-suite" ] {with-test & rocq-core:installed}
+       ]
+install: [ make "install" ]
+depends: [
+  ("coq" {>= "8.18" & < "8.20~"} & "coq-elpi" {>= "2.0"}
+  | "coq" {>= "8.20" & < "8.21~"} & "coq-elpi" {>= "2.4" | = "dev"}
+  | "rocq-core" {(>= "9.0" & < "9.1~") | = "dev"} & "rocq-elpi" {>= "2.4" | = "dev"})
+]
+conflicts: [
+  "coq-hierarchy-builder" {< "1.9~"}
+  "coq-hierarchy-builder-shim"
+]
+depexts: [
+  [ "wdiff" ] {os-family = "debian" & with-test}
+]
+synopsis: "High level commands to declare and evolve a hierarchy based on packed classes"
+description: """
+Hierarchy Builder is a high level language to build hierarchies of algebraic structures and make these
+hierarchies evolve without breaking user code. The key concepts are the ones of factory, builder
+and abbreviation that let the hierarchy developer describe an actual interface for their library.
+Behind that interface the developer can provide appropriate code to ensure retro compatibility.
+"""
+tags: [ "logpath:HB" ]
+url {
+  src:
+    "https://github.com/math-comp/hierarchy-builder/releases/download/v1.9.1/hierarchy-builder-1.9.1.tar.gz"
+  checksum: [
+    "sha512=8d3be72019ade2e696b94ce3512d615d81e289743ccb592817ecb542c439e2bfc2650501d5bd82f349ea584094ffc534ae657b95a09390bd392c2ba3eb426402"
+  ]
+}


### PR DESCRIPTION
Minor release fixing compilation on macos

ci-skip: rocq-hierarchy-builder