### PR TITLE
Normalize coq.dev opam file

### DIFF
--- a/core-dev/packages/coq/coq.dev/opam
+++ b/core-dev/packages/coq/coq.dev/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Compatibility metapackage for Coq after the Rocq renaming"
-maintainer: ["The Rocq development team <coqdev@inria.fr>"]
-authors: ["The Rocq development team, INRIA, CNRS, and contributors"]
+maintainer: "The Rocq development team <coqdev@inria.fr>"
+authors: "The Rocq development team, INRIA, CNRS, and contributors"
 license: "LGPL-2.1-only"
 homepage: "https://rocq-prover.org/"
 doc: "https://rocq-prover.org/docs/"
@@ -13,4 +13,3 @@ depends: [
   "coqide-server" {= version}
 ]
 dev-repo: "git+https://github.com/rocq-prover/rocq.git"
-build: []


### PR DESCRIPTION
possibly prevent spurious "recompilation" https://rocq-prover.zulipchat.com/#narrow/channel/237656-Rocq-devs-.26-plugin-devs/topic/weird.20bench.20behaviour/with/515482353

copied the file from .opam-switch/packages in some bench

idea based on https://github.com/ocaml/opam/issues/5814#issuecomment-2039278095

I guess we will see if it works next bench