### PR TITLE
`lra` of algebra-tactics not compatible with MathComp 2.4.0

### DIFF
--- a/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.1.2.4/opam
+++ b/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.1.2.4/opam
@@ -24,7 +24,7 @@ build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
   "coq" {>= "8.16" & < "9.1~"}
-  "coq-mathcomp-ssreflect" {>= "2.0" & < "2.5~"}
+  "coq-mathcomp-ssreflect" {>= "2.0" & < "2.4~"}
   "coq-mathcomp-algebra"
   "coq-mathcomp-zify" {>= "1.5.0"}
   "coq-elpi" {>= "1.15.0" & != "1.17.0"}


### PR DESCRIPTION
@proux01 