### PR TITLE
[extra-dev] Add missing rocq-hierarchy-builder.dev

### DIFF
--- a/extra-dev/packages/coq-hierarchy-builder/coq-hierarchy-builder.dev/opam
+++ b/extra-dev/packages/coq-hierarchy-builder/coq-hierarchy-builder.dev/opam
@@ -6,27 +6,9 @@ homepage: "https://github.com/math-comp/hierarchy-builder"
 bug-reports: "https://github.com/math-comp/hierarchy-builder/issues"
 dev-repo: "git+https://github.com/math-comp/hierarchy-builder"
 
-build: [ [ make "build"]
-         [ make "test-suite" ] {with-test & rocq-core:installed}
-       ]
-install: [ make "install" ]
 depends: [
-  ("coq" {>= "8.18" & < "8.20~"} & "coq-elpi" {>= "2.0"}
-  | "coq" {>= "8.20" & < "8.21~"} & "coq-elpi" {>= "2.4" | = "dev"}
-  | "rocq-core" {>= "9.0" | = "dev"} & "coq-elpi" {>= "2.4" | = "dev"})
+  "coq-core"
+  "rocq-hierarchy-builder" {= version}
 ]
-depexts: [
-  [ "wdiff" ] {os-family = "debian" & with-test}
-]
-conflicts: [ "coq-hierarchy-builder-shim" ]
-synopsis: "High level commands to declare and evolve a hierarchy based on packed classes"
-description: """
-Hierarchy Builder is a high level language to build hierarchies of algebraic structures and make these
-hierarchies evolve without breaking user code. The key concepts are the ones of factory, builder
-and abbreviation that let the hierarchy developer describe an actual interface for their library.
-Behind that interface the developer can provide appropriate code to ensure retro compatibility.
-"""
-tags: [ "logpath:HB" ]
-url {
-  src: "git+https://github.com/math-comp/hierarchy-builder.git#master"
-}
+
+synopsis: "Compatibility package for rocq-hierarchy-builder"

--- a/extra-dev/packages/rocq-hierarchy-builder/rocq-hierarchy-builder.dev/opam
+++ b/extra-dev/packages/rocq-hierarchy-builder/rocq-hierarchy-builder.dev/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Cyril Cohen" "Kazuhiko Sakaguchi" "Enrico Tassi" ]
+license: "MIT"
+homepage: "https://github.com/math-comp/hierarchy-builder"
+bug-reports: "https://github.com/math-comp/hierarchy-builder/issues"
+dev-repo: "git+https://github.com/math-comp/hierarchy-builder"
+
+build: [ [ make "build"]
+         [ make "test-suite" ] {with-test}
+       ]
+install: [ make "install" ]
+depends: [
+  "rocq-core" {>= "9.0" | = "dev"}
+  "rocq-elpi" {>= "2.4" | = "dev"}
+]
+conflicts: [
+  "coq-hierarchy-builder" {< "1.9~"}
+  "coq-hierarchy-builder-shim"
+]
+depexts: [
+  [ "wdiff" ] {os-family = "debian" & with-test}
+]
+synopsis: "High level commands to declare and evolve a hierarchy based on packed classes"
+description: """
+Hierarchy Builder is a high level language to build hierarchies of algebraic structures and make these
+hierarchies evolve without breaking user code. The key concepts are the ones of factory, builder
+and abbreviation that let the hierarchy developer describe an actual interface for their library.
+Behind that interface the developer can provide appropriate code to ensure retro compatibility.
+"""
+tags: [ "logpath:HB" ]
+url {
+  src: "git+https://github.com/math-comp/hierarchy-builder.git#master"
+}


### PR DESCRIPTION
ci-skip: rocq-hierarchy-builder