### PR TITLE
Packages rocq-num-analysis*.2.0.0.

### DIFF
--- a/released/packages/rocq-num-analysis-algebra/rocq-num-analysis-algebra.2.0.0/opam
+++ b/released/packages/rocq-num-analysis-algebra/rocq-num-analysis-algebra.2.0.0/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+
+name: "rocq-num-analysis-algebra"
+version: "2.0.0"
+synopsis: "Algebraic structures for numerical analysis in Rocq"
+description: """
+This library is based on Coquelicot and provides additional support about
+commutative monoids, Abelian groups, rings, module spaces, and affine spaces.
+This includes support for functions to a given algebraic structure, iterated
+operations (sum, linear combination, barycenter), morphisms, algebraic
+substructures, and the specific case of finite dimension.
+It is based on classical logic.
+"""
+
+homepage: "https://lipn.univ-paris13.fr/rocq-num-analysis/"
+dev-repo: "git+https://lipn.univ-paris13.fr/rocq-num-analysis.git"
+bug-reports: "https://lipn.univ-paris13.fr/rocq-num-analysis/issues"
+doc: "https://lipn.univ-paris13.fr/rocqdoc-num-analysis/2.0/"
+maintainer: "MILC project <milc@inria.fr>"
+authors: [
+  "Sylvie Boldo"
+  "François Clément"
+  "Vincent Martin"
+  "Micaela Mayero"
+  "Florian Faissole"
+  "Houda Mouhcine"
+  "Louise Leclerc"
+  "Stéphane Aubry"
+]
+license: "LGPL-3.0-or-later"
+
+depends: [
+  ("coq" {>= "8.20" & < "8.21~"} | "rocq-prover" {>= "9.0" & < "9.1~"})
+  "coq-coquelicot" {>= "3.4" & < "3.5"}
+  "rocq-num-analysis-subset" {= version}
+]
+
+build: [ make "-C" "Algebra" "-j%{jobs}%" ]
+install: [ make "-C" "Algebra" "install" ]
+remove: [ make "-C" "Algebra" "uninstall" ]
+
+url {
+  src: "https://lipn.univ-paris13.fr/rocq-num-analysis-releases/rocq-num-analysis-2.0.0.tar.gz"
+  checksum: "sha512=b2453dc67f2b716ea0a473ca9942eacd3e1eed29493395e35eac5b997e840ec95ed4b028a416b1e92c9a88403cf01812f7744fbc1f0dc8fa8596a2d5c4b8b9b1"
+}
+
+tags: [
+  "category:Math/Algebra"
+
+  "date:2025-06"
+
+  "logpath:NumAnalysis.Algebra"
+
+  "keyword:algebra"
+  "keyword:algebraic structure hierarchy"
+  "keyword:functions to an algebraic structure"
+  "keyword:algebraic substructure"
+  "keyword:morphism"
+  "keyword:monoid"
+  "keyword:group"
+  "keyword:ring"
+  "keyword:module space"
+  "keyword:affine space"
+  "keyword:dimension theorem"
+  "keyword:incomplete basis theorem"
+  "keyword:dual basis"
+  "keyword:predual basis"
+  "keyword:rank-nullity theorem"
+  "keyword:binomial coefficient"
+]

--- a/released/packages/rocq-num-analysis-fem/rocq-num-analysis-fem.2.0.0/opam
+++ b/released/packages/rocq-num-analysis-fem/rocq-num-analysis-fem.2.0.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+
+name: "rocq-num-analysis-fem"
+version: "2.0.0"
+synopsis: "The finite element method"
+description: """
+This library provides support for finite elements, including the simplicial
+Lagrange finite element family. It is based on classical logic.
+"""
+
+homepage: "https://lipn.univ-paris13.fr/rocq-num-analysis/"
+dev-repo: "git+https://lipn.univ-paris13.fr/rocq-num-analysis.git"
+bug-reports: "https://lipn.univ-paris13.fr/rocq-num-analysis/issues"
+doc: "https://lipn.univ-paris13.fr/rocqdoc-num-analysis/2.0/"
+maintainer: "MILC project <milc@inria.fr>"
+authors: [
+  "Sylvie Boldo"
+  "François Clément"
+  "Vincent Martin"
+  "Micaela Mayero"
+  "Florian Faissole"
+  "Houda Mouhcine"
+  "Louise Leclerc"
+  "Stéphane Aubry"
+]
+license: "LGPL-3.0-or-later"
+
+depends: [
+  ("coq" {>= "8.20" & < "8.21~"} | "rocq-prover" {>= "9.0" & < "9.1~"})
+  "rocq-num-analysis-algebra" {= version}
+]
+
+build: [ make "-C" "FEM" "-j%{jobs}%" ]
+install: [ make "-C" "FEM" "install" ]
+remove: [ make "-C" "FEM" "uninstall" ]
+
+url {
+  src: "https://lipn.univ-paris13.fr/rocq-num-analysis-releases/rocq-num-analysis-2.0.0.tar.gz"
+  checksum: "sha512=b2453dc67f2b716ea0a473ca9942eacd3e1eed29493395e35eac5b997e840ec95ed4b028a416b1e92c9a88403cf01812f7744fbc1f0dc8fa8596a2d5c4b8b9b1"
+}
+
+tags: [
+  "category:Math/Real Calculus and Topology"
+
+  "date:2025-06"
+
+  "logpath:NumAnalysis.FEM"
+
+  "keyword:multi-index"
+  "keyword:multi-variate polynomial"
+  "keyword:Lagrange polynomial"
+  "keyword:finite element"
+  "keyword:simplicial Lagrange finite element"
+]

--- a/released/packages/rocq-num-analysis-lax-milgram/rocq-num-analysis-lax-milgram.2.0.0/opam
+++ b/released/packages/rocq-num-analysis-lax-milgram/rocq-num-analysis-lax-milgram.2.0.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+
+name: "rocq-num-analysis-lax-milgram"
+version: "2.0.0"
+synopsis: "Lax-Milgram theorem"
+description: """
+This library provides support for the proof of the Lax-Milgram theorem.
+It is based on classical logic.
+"""
+
+homepage: "https://lipn.univ-paris13.fr/rocq-num-analysis/"
+dev-repo: "git+https://lipn.univ-paris13.fr/rocq-num-analysis.git"
+bug-reports: "https://lipn.univ-paris13.fr/rocq-num-analysis/issues"
+doc: "https://lipn.univ-paris13.fr/rocqdoc-num-analysis/2.0/"
+maintainer: "MILC project <milc@inria.fr>"
+authors: [
+  "Sylvie Boldo"
+  "François Clément"
+  "Vincent Martin"
+  "Micaela Mayero"
+  "Florian Faissole"
+  "Houda Mouhcine"
+  "Louise Leclerc"
+  "Stéphane Aubry"
+]
+license: "LGPL-3.0-or-later"
+
+depends: [
+  ("coq" {>= "8.20" & < "8.21~"} | "rocq-prover" {>= "9.0" & < "9.1~"})
+  "rocq-num-analysis-algebra" {= version}
+]
+
+build: [ make "-C" "LM" "-j%{jobs}%" ]
+install: [ make "-C" "LM" "install" ]
+remove: [ make "-C" "LM" "uninstall" ]
+
+url {
+  src: "https://lipn.univ-paris13.fr/rocq-num-analysis-releases/rocq-num-analysis-2.0.0.tar.gz"
+  checksum: "sha512=b2453dc67f2b716ea0a473ca9942eacd3e1eed29493395e35eac5b997e840ec95ed4b028a416b1e92c9a88403cf01812f7744fbc1f0dc8fa8596a2d5c4b8b9b1"
+}
+
+tags: [
+  "category:Math/Real Calculus and Topology"
+
+  "date:2025-06"
+
+  "logpath:NumAnalysis.LM"
+
+  "keyword:fixed point theorem (in a Banach space)"
+  "keyword:orthogonal projection"
+  "keyword:orthogonal complement"
+  "keyword:Riesz-Fréchet representation theorem"
+  "keyword:Lax-Milgram theorem"
+  "keyword:Céa's lemma"
+]

--- a/released/packages/rocq-num-analysis-lebesgue/rocq-num-analysis-lebesgue.2.0.0/opam
+++ b/released/packages/rocq-num-analysis-lebesgue/rocq-num-analysis-lebesgue.2.0.0/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+
+name: "rocq-num-analysis-lebesgue"
+version: "2.0.0"
+synopsis: "Lebesgue integral"
+description: """
+This library provides support for the Lebesgue integral of nonnegative
+measurable functions, and for the Bochner integral for functions to a Banach
+space. It is based on classical logic.
+"""
+
+homepage: "https://lipn.univ-paris13.fr/rocq-num-analysis/"
+dev-repo: "git+https://lipn.univ-paris13.fr/rocq-num-analysis.git"
+bug-reports: "https://lipn.univ-paris13.fr/rocq-num-analysis/issues"
+doc: "https://lipn.univ-paris13.fr/rocqdoc-num-analysis/2.0/"
+maintainer: "MILC project <milc@inria.fr>"
+authors: [
+  "Sylvie Boldo"
+  "François Clément"
+  "Vincent Martin"
+  "Micaela Mayero"
+  "Florian Faissole"
+  "Houda Mouhcine"
+  "Louise Leclerc"
+  "Stéphane Aubry"
+]
+license: "LGPL-3.0-or-later"
+
+depends: [
+  ("coq" {>= "8.20" & < "8.21~"} | "rocq-prover" {>= "9.0" & < "9.1~"})
+  "coq-coquelicot" {>= "3.4" & < "3.5"}
+  "coq-flocq" {>= "4.2" & < "4.3~"}
+  "rocq-num-analysis-subset" {= version}
+]
+
+build: [ make "-C" "Lebesgue" "-j%{jobs}%" ]
+install: [ make "-C" "Lebesgue" "install" ]
+remove: [ make "-C" "Lebesgue" "uninstall" ]
+
+url {
+  src: "https://lipn.univ-paris13.fr/rocq-num-analysis-releases/rocq-num-analysis-2.0.0.tar.gz"
+  checksum: "sha512=b2453dc67f2b716ea0a473ca9942eacd3e1eed29493395e35eac5b997e840ec95ed4b028a416b1e92c9a88403cf01812f7744fbc1f0dc8fa8596a2d5c4b8b9b1"
+}
+
+tags: [
+  "category:Math/Real Calculus and Topology"
+
+  "date:2025-06"
+
+  "logpath:NumAnalysis.Lebesgue"
+
+  "keyword:sigma-algebra"
+  "keyword:monotone class theorem"
+  "keyword:Dynkin pi-lambda theorem"
+  "keyword:measure theory"
+  "keyword:Lebesgue measure"
+  "keyword:simple function"
+  "keyword:adapted sequence"
+  "keyword:Beppo Levi (monotone convergence) theorem"
+  "keyword:Fatou lemma"
+  "keyword:Lebesgue (dominated convergence) theorem"
+  "keyword:Lebesgue induction principle"
+  "keyword:Tonelli theorem"
+  "keyword:Bochner integral"
+]

--- a/released/packages/rocq-num-analysis-subset/rocq-num-analysis-subset.2.0.0/opam
+++ b/released/packages/rocq-num-analysis-subset/rocq-num-analysis-subset.2.0.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+
+name: "rocq-num-analysis-subset"
+version: "2.0.0"
+synopsis: "Subsets for numerical analysis in Rocq"
+description: """
+This library provides support about subsets, functions, homogeneous binary
+relations, and finite families. It is based on classical logic.
+Some complements about logic and natural numbers are also provided.
+"""
+
+homepage: "https://lipn.univ-paris13.fr/rocq-num-analysis/"
+dev-repo: "git+https://lipn.univ-paris13.fr/rocq-num-analysis.git"
+bug-reports: "https://lipn.univ-paris13.fr/rocq-num-analysis/issues"
+doc: "https://lipn.univ-paris13.fr/rocqdoc-num-analysis/2.0/"
+maintainer: "MILC project <milc@inria.fr>"
+authors: [
+  "Sylvie Boldo"
+  "François Clément"
+  "Vincent Martin"
+  "Micaela Mayero"
+  "Florian Faissole"
+  "Houda Mouhcine"
+  "Louise Leclerc"
+  "Stéphane Aubry"
+]
+license: "LGPL-3.0-or-later"
+
+depends: [
+  ("coq" {>= "8.20" & < "8.21~"} | "rocq-prover" {>= "9.0" & < "9.1~"})
+  "coq-mathcomp-ssreflect" {>= "2.3" & < "2.5~"}
+  "coq-mathcomp-classical" {>= "1.8" & < "1.12~"}
+]
+
+build: [ make "-C" "Subset" "-j%{jobs}%" ]
+install: [ make "-C" "Subset" "install" ]
+remove: [ make "-C" "Subset" "uninstall" ]
+
+url {
+  src: "https://lipn.univ-paris13.fr/rocq-num-analysis-releases/rocq-num-analysis-2.0.0.tar.gz"
+  checksum: "sha512=b2453dc67f2b716ea0a473ca9942eacd3e1eed29493395e35eac5b997e840ec95ed4b028a416b1e92c9a88403cf01812f7744fbc1f0dc8fa8596a2d5c4b8b9b1"
+}
+
+tags: [
+  "category:Math/Logic/Set theory"
+
+  "date:2025-06"
+
+  "logpath:NumAnalysis.Requisite"
+  "logpath:NumAnalysis.Logic"
+  "logpath:NumAnalysis.Numbers"
+  "logpath:NumAnalysis.Subsets"
+
+  "keyword:subset"
+  "keyword:function"
+  "keyword:homogeneous binary relation"
+  "keyword:operation on finite families"
+]

--- a/released/packages/rocq-num-analysis/rocq-num-analysis.2.0.0/opam
+++ b/released/packages/rocq-num-analysis/rocq-num-analysis.2.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+
+name: "rocq-num-analysis"
+version: "2.0.0"
+synopsis: "Numerical analysis in Rocq"
+description: """
+Meta-package grouping rocq-num-analysis-lebesgue,
+rocq-num-analysis-lax-milgram and rocq-num-analysis-fem.
+"""
+
+homepage: "https://lipn.univ-paris13.fr/rocq-num-analysis/"
+dev-repo: "git+https://lipn.univ-paris13.fr/rocq-num-analysis.git"
+bug-reports: "https://lipn.univ-paris13.fr/rocq-num-analysis/issues"
+doc: "https://lipn.univ-paris13.fr/rocqdoc-num-analysis/2.0/"
+maintainer: "MILC project <milc@inria.fr>"
+authors: [
+  "Sylvie Boldo"
+  "François Clément"
+  "Vincent Martin"
+  "Micaela Mayero"
+  "Florian Faissole"
+  "Houda Mouhcine"
+  "Louise Leclerc"
+  "Stéphane Aubry"
+]
+license: "LGPL-3.0-or-later"
+
+depends: [
+  "rocq-num-analysis-lebesgue" {= version}
+  "rocq-num-analysis-lax-milgram" {= version}
+  "rocq-num-analysis-fem" {= version}
+]


### PR DESCRIPTION
Hi,
This PR corresponds to 6 related packages: rocq-num-analysis{-subset,-algebra,-lebesgue,-lax-milgram,-fem,}.
RNA-algebra and RNA-lebesgue both depend on RNA-subset.
RNA-lax-milgram and RNA-fem both depend on RNA-algebra.
RNA is a metapackage providing everything (ie depending on RNA-lebesgue, RNA-lax-milgram and RNA-fem).
All this should compile with Coq-8.20 and Rocq-9.0.
Best wishes,
François