### PR TITLE
coq-io-tree 0.1.0 is compatible with coq 8.11

### DIFF
--- a/released/packages/coq-itree-io/coq-itree-io.0.1.0/opam
+++ b/released/packages/coq-itree-io/coq-itree-io.0.1.0/opam
@@ -13,7 +13,7 @@ Interpret itree in the IO monad of simple-io."""
 build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
-  "coq" { >= "8.12~" < "8.17" }
+  "coq" { >= "8.11~" < "8.17" }
   "coq-itree" { >= "3.2.0" }
   "coq-simple-io" { >= "1.3.0" }
 ]


### PR DESCRIPTION
In PR https://github.com/rocq-prover/opam/pull/2628, a constraint for Coq > 8.11 was added to coq-io-tree.0.1.0. However, this package is known to work on 8.11. This PR widens the constraint.