### PR TITLE
Add upper bound < 9.1.0 for coq-hammer-tactics

### DIFF
--- a/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.3.2+8.20/opam
+++ b/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.3.2+8.20/opam
@@ -21,7 +21,7 @@ install: [
 ]
 depends: [
   "ocaml" { >= "4.09" }
-  "coq" {>= "8.20" & < "8.21~"}
+  "coq" {>= "8.20" & < "9.1.0"}
 ]
 
 conflicts: [


### PR DESCRIPTION
This PR adds an upper bound < "9.1.0" to the coq dependency for the following package(s):
- coq-hammer-tactics

This is required for compatibility with Rocq 9.0 and was tested successfully as part of the Rocq Platform 9.0 release preparation.

/cc @MSoegtropIMC 