### PR TITLE
Add upper bound < 9.1.0 for coq-itauto

### DIFF
--- a/released/packages/coq-itauto/coq-itauto.8.20.0/opam
+++ b/released/packages/coq-itauto/coq-itauto.8.20.0/opam
@@ -21,7 +21,7 @@ build: [
 install: [make "install"]
 depends: [
   "ocaml" {>= "4.9~"}
-  "coq" {>= "8.20" & < "8.21"}
+  "coq" {>= "8.20" & < "9.1.0"}
   "dune" {>= "2.9"}
 ]
 depopts: [ "ocamlformat" {build} ]


### PR DESCRIPTION
This PR adds an upper bound < "9.1.0" to the coq dependency for the following package(s):
- coq-itauto

This is required for compatibility with Rocq 9.0 and was tested successfully as part of the Rocq Platform 9.0 release preparation.

/cc @MSoegtropIMC 