### PR TITLE
Add upper bound < 9.1.0 for coq-unicoq

### DIFF
--- a/released/packages/coq-unicoq/coq-unicoq.1.6+8.20/opam
+++ b/released/packages/coq-unicoq/coq-unicoq.1.6+8.20/opam
@@ -14,7 +14,7 @@ install: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.20" & < "9.1.0"}
+  "coq" {>= "8.20" & < "9.1.0~"}
 ]
 synopsis: "An enhanced unification algorithm for Coq"
 tags: [

--- a/released/packages/coq-unicoq/coq-unicoq.1.6+8.20/opam
+++ b/released/packages/coq-unicoq/coq-unicoq.1.6+8.20/opam
@@ -14,7 +14,7 @@ install: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.20" & < "8.21~"}
+  "coq" {>= "8.20" & < "9.1.0"}
 ]
 synopsis: "An enhanced unification algorithm for Coq"
 tags: [


### PR DESCRIPTION
This PR adds an upper bound `< "9.1.0"` to the `coq` dependency for the following package(s):
- coq-unicoq

This is required for compatibility with Coq 9.0 and was tested successfully as part of the Rocq Platform 9.0 release preparation.

/cc @MSoegtropIMC 