### PR TITLE
Fix: change < 9.1.0 to < 9.1.0~ for correct pre-release handling

### DIFF
--- a/released/packages/coq-coqprime/coq-coqprime.1.6.0/opam
+++ b/released/packages/coq-coqprime/coq-coqprime.1.6.0/opam
@@ -13,7 +13,7 @@ install: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.20" & < "9.1.0"}
+  "coq" {>= "8.20" & < "9.1.0~"}
   "coq-bignums"
 ]
 synopsis: "Certifying prime numbers in Coq"


### PR DESCRIPTION
Fix upper bound on Coq dependency: change < "9.1.0" to < "9.1.0~"

/cc @MSoegtropIMC 