### PR TITLE
Fix: change < 9.1.0 to < 9.1.0~ for correct pre-release handling

### DIFF
--- a/released/packages/coq-itauto/coq-itauto.8.20.0/opam
+++ b/released/packages/coq-itauto/coq-itauto.8.20.0/opam
@@ -21,7 +21,7 @@ build: [
 install: [make "install"]
 depends: [
   "ocaml" {>= "4.9~"}
-  "coq" {>= "8.20" & < "9.1.0"}
+  "coq" {>= "8.20" & < "9.1.0~"}
   "dune" {>= "2.9"}
 ]
 depopts: [ "ocamlformat" {build} ]


### PR DESCRIPTION
This PR fixes the upper bound of the Coq dependency from < "9.1.0" to < "9.1.0~"

/cc @MSoegtropIMC 