### PR TITLE
coq-ordinal 0.5.6 support Rocq 9.0.0

### DIFF
--- a/released/packages/coq-ordinal/coq-ordinal.0.5.6/opam
+++ b/released/packages/coq-ordinal/coq-ordinal.0.5.6/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "jaehyung.lee@sf.snu.ac.kr"
+synopsis: "Ordinal Numbers in Coq"
+homepage: "https://github.com/snu-sf/Ordinal"
+dev-repo: "git+https://github.com/snu-sf/Ordinal"
+bug-reports: "https://github.com/snu-sf/Ordinal/issues"
+authors: [
+  "Minki Cho <minki.cho@sf.snu.ac.kr>"
+]
+license: "MIT"
+build: [make "-j%{jobs}%"]
+install: [make "-f" "Makefile.coq" "install"]
+depends: [
+  "coq" {>= "8.13" & < "9.1~"}
+]
+tags: [
+  "date:2025-08-03"
+
+  "category:Mathematics/Logic"
+
+  "keyword:ordinal numbers"
+  "keyword:set theory"
+
+  "logpath:Ordinal"
+]
+url {
+  http: "https://github.com/snu-sf/Ordinal/archive/refs/tags/v0.5.6.tar.gz"
+  checksum: "sha512=b7b5e03736f01e700d307104f690594822376c29a4cd7c584b51c379ccbb7f44fe070db192edeba2a3cb3e6e84d8050043b004946733494ca59eeaaa53b309e5"
+}

--- a/released/packages/coq-ordinal/coq-ordinal.0.5.6/opam
+++ b/released/packages/coq-ordinal/coq-ordinal.0.5.6/opam
@@ -11,7 +11,7 @@ license: "MIT"
 build: [make "-j%{jobs}%"]
 install: [make "-f" "Makefile.coq" "install"]
 depends: [
-  "coq" {>= "8.13" & < "9.1~"}
+  "coq" {>= "8.15.2" & < "9.1~"}
 ]
 tags: [
   "date:2025-08-03"
@@ -25,5 +25,5 @@ tags: [
 ]
 url {
   http: "https://github.com/snu-sf/Ordinal/archive/refs/tags/v0.5.6.tar.gz"
-  checksum: "sha512=b7b5e03736f01e700d307104f690594822376c29a4cd7c584b51c379ccbb7f44fe070db192edeba2a3cb3e6e84d8050043b004946733494ca59eeaaa53b309e5"
+  checksum: "sha512=753507ae5bc2d4bb02bd3e60f704c2631afb3238b1c0aabc6022a81cbc28e783f30f227a3968febe422c07e7279fb435b14911d12f47e72c0ab60ce47d7e8e55"
 }


### PR DESCRIPTION
Add coq-ordinal 0.5.6, which supports Rocq 9.0.0