### PR TITLE
Package rocq-navi.0.3.0

### DIFF
--- a/released/packages/rocq-navi/rocq-navi.0.3.0/opam
+++ b/released/packages/rocq-navi/rocq-navi.0.3.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Yoshihiro Imai<y.imai@aist.go.jp>"
+
+homepage: "https://github.com/affeldt-aist/rocqnavi"
+dev-repo: "git+https://github.com/yoshihiro503/rocqnavi.git"
+bug-reports: "https://github.com/affeldt-aist/rocqnavi/issues"
+
+license: "GPL-2.0-or-later"
+synopsis: "Extension of coq2html Document Generator"
+
+description: """
+Extension of coq2html Document Generator"""
+
+build: [make]
+install: [make "BINDIR=%{bin}%" "install"]
+depends: [
+  "ocaml" {>= "4.14"}
+  "ocamlfind"
+  "dune-glob" # Parsing glob syntax like "*_unnamed_mixin_*"
+]
+
+tags: [
+  "category:Tools/Document Generator"
+  "keyword:document"
+  "keyword:html"
+  "logpath:"
+]
+authors: [
+  "Xavier Leroy <xavier.leroy@college-de-france.fr>"
+  "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+  "Yoshihiro Imai <y.imai@aist.go.jp>"
+]
+
+url {
+  src:
+    "https://github.com/affeldt-aist/rocqnavi/archive/refs/tags/rocqnavi.0.3.0.tar.gz"
+  checksum: [
+    "md5=e7c03ee7be5dd7e3c408af6a165e339a"
+    "sha512=efe49d88ddf0ce149530b89b1a63163839474a85a817f80002f7d55e40de0a6e6745f5cadd1f6fc8ce67dce7f5a2461527630278794d19aa431c4fa5c23ad940"
+  ]
+}


### PR DESCRIPTION
### `rocq-navi.0.3.0`
Extension of coq2html Document Generator
Extension of coq2html Document Generator



---
* Homepage: https://github.com/affeldt-aist/rocqnavi
* Source repo: git+https://github.com/yoshihiro503/rocqnavi.git
* Bug tracker: https://github.com/affeldt-aist/rocqnavi/issues

---
:camel: Pull-request generated by opam-publish v2.5.1