### PR TITLE
Package coq-reduction-effects.0.1.6

### DIFF
--- a/released/packages/coq-reduction-effects/coq-reduction-effects.0.1.6/opam
+++ b/released/packages/coq-reduction-effects/coq-reduction-effects.0.1.6/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis:
+  "A Coq plugin to add reduction side effects to some Coq reduction strategies"
+maintainer: "Yishuai Li <yishuai@cis.upenn.edu>"
+authors: "Hugo Herbelin"
+license: "MPL-2.0"
+tags: "logpath:ReductionEffect"
+homepage: "https://github.com/coq-community/reduction-effects"
+bug-reports: "https://github.com/coq-community/reduction-effects/issues"
+depends: [
+  "coq" {>= "8.10"}
+  "cppo" {>= "1.6.8"}
+]
+build: [make "-j%{jobs}%"]
+run-test: [make "-j%{jobs}%" "test"]
+install: [make "install"]
+dev-repo: "git+https://github.com/coq-community/reduction-effects.git"
+url {
+  src:
+    "https://github.com/rocq-community/reduction-effects/archive/refs/tags/v0.1.6.tar.gz"
+  checksum: [
+    "md5=cf98e2d1df03ad74339fd8145313cdab"
+    "sha512=4afdd1b18212e50e01a89398facad9d45aa707dfabdb179df04fcfff0e569eaad65c33336c2962cacc7d633031ad851c11c161dbf3531576e62bf1eb2db1a17b"
+  ]
+}


### PR DESCRIPTION
### `coq-reduction-effects.0.1.6`
A Coq plugin to add reduction side effects to some Coq reduction strategies

Closes rocq-community/reduction-effects#26
Closes rocq-community/reduction-effects#27

---
* Homepage: https://github.com/coq-community/reduction-effects
* Source repo: git+https://github.com/coq-community/reduction-effects.git
* Bug tracker: https://github.com/coq-community/reduction-effects/issues

---
:camel: Pull-request generated by opam-publish v2.5.1