### PR TITLE
Package coq-menhirlib.20250903

### DIFF
--- a/released/packages/coq-menhirlib/coq-menhirlib.20250903/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20250903/opam
@@ -1,0 +1,35 @@
+
+opam-version: "2.0"
+synopsis: "A support library for verified Coq parsers produced by Menhir"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "Jacques-Henri Jourdan <jacques-henri.jourdan@lri.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/coq-menhirlib"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
+bug-reports: "https://gitlab.inria.fr/fpottier/menhir/-/issues"
+license: "LGPL-3.0-or-later"
+build: [
+  [make "-C" "coq-menhirlib" "-j%{jobs}%"]
+]
+install: [
+  [make "-C" "coq-menhirlib" "install"]
+]
+depends: [
+  "coq" { >= "8.7" }
+]
+conflicts: [
+  "menhir" { != version }
+]
+tags: [
+  "date:2025-09-03"
+  "logpath:MenhirLib"
+]
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/menhir/-/archive/20250903/archive.tar.gz"
+  checksum: [
+    "md5=5ecb7f71cf374147d3d3137c6e2fe382"
+    "sha512=66393a5b9ba49baf65cac10ec85b0da16dfcf8e7cf55ffeb847b9339f310dfe65e2b3e2b33e215de7b074466adc7f0c43234f476f6fd31cab9fb75f71bd8b2ac"
+  ]
+}


### PR DESCRIPTION
### `coq-menhirlib.20250903`
A support library for verified Coq parsers produced by Menhir



---
* Homepage: https://gitlab.inria.fr/fpottier/coq-menhirlib
* Source repo: git+https://gitlab.inria.fr/fpottier/menhir.git
* Bug tracker: https://gitlab.inria.fr/fpottier/menhir/-/issues

---
:camel: Pull-request generated by opam-publish v2.5.0