### PR TITLE
CompCert 3.16

### DIFF
--- a/released/packages/coq-compcert/coq-compcert.3.16/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.16/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "The CompCert C compiler (64 bit)"
+maintainer: "Michael Soegtrop and Xavier Leroy"
+authors: "Xavier Leroy <xavier.leroy@college-de-france.fr>"
+license: "INRIA Non-Commercial License Agreement"
+tags: [
+  "category:Computer Science/Semantics and Compilation/Compilation"
+  "category:Computer Science/Semantics and Compilation/Semantics"
+  "keyword:C"
+  "keyword:compiler"
+  "logpath:compcert"
+  "date:2025-09-01"
+]
+homepage: "https://compcert.org/"
+bug-reports: "https://github.com/AbsInt/CompCert/issues"
+depends: [
+  "coq" {>= "8.15.0" & < "9.1~"}
+  "menhir" {>= "20200624" & != "dev"}
+  "ocaml" {>= "4.05.0" & < "5~"}
+  "coq-flocq" {>= "4.1.0" & < "5~"}
+  "coq-menhirlib" {>= "20200624"}
+]
+build: [
+  [
+    "./configure"
+    "amd64-linux" {os = "linux" & arch = "x86_64"}
+    "amd64-macosx" {os = "macos" & arch = "x86_64"}
+    "arm64-linux" {os = "linux" & (arch = "arm64" | arch = "aarch64")}
+    "arm64-macosx" {os = "macos" & (arch = "arm64" | arch = "aarch64")}
+    "amd64-cygwin" {os = "cygwin"}
+    "amd64-cygwin" {os = "win32" & os-distribution = "cygwinports"}
+    "-toolprefix"
+      {os = "win32" & os-distribution = "cygwinports" & arch = "i686"}
+    "x86_64-pc-cygwin-"
+      {os = "win32" & os-distribution = "cygwinports" & arch = "i686"}
+    "-prefix"
+    "%{prefix}%"
+    "-install-coqdev"
+    "-clightgen"
+    "-use-external-Flocq"
+    "-use-external-MenhirLib"
+    "-coqdevdir"
+    "%{lib}%/coq/user-contrib/compcert"
+    "-ignore-coq-version"
+  ]
+  [make "-j%{jobs}%" {ocaml:version >= "4.06"}]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/AbsInt/CompCert.git"
+url {
+  src: "https://github.com/AbsInt/CompCert/archive/v3.16.tar.gz"
+  checksum: [
+    "sha256=78ebd29e0c7d37cede785850100722f1de21464059c5eda14a992c828c4b7d59"
+    "sha512=0e448e394a8ba4dbc84da6bb1d4635f39c98453971fb614ae57f364c1c3ef0677404a2bb02473d0a180181826cb324b2b9f5d95d1303f741a9d3b03afb354cf3"
+  ]
+}


### PR DESCRIPTION
Code generation and optimization

-   Extend neededness analysis to 64-bit integer operations, enabling more useless integer computations to be removed.
-   Extend common subexpression elimination (CSE) and dead code elimination to calls to known pure built-in functions and to known pure arithmetic helper functions.
 -  Generation of position-independent code (PIC) for AArch64, RISC-V and x86-64 (option -fpic) (https://github.com/AbsInt/CompCert/pull/551)
 -  Generation of position-independent executables (PIE) for AArch64, RISC-V and x86-64 (option -fpie) (https://github.com/AbsInt/CompCert/pull/551)
 -  RISC-V: use PC-relative addressing instead of absolute addressing where possible (https://github.com/AbsInt/CompCert/pull/550)
 -  PowerPC and x86/ELF: put jump tables in .rodata section instead of .text section (https://github.com/AbsInt/CompCert/issues/508)

Bug fixes

 -  Reject identifiers consisting of a single $ sign. This can cause errors with some assemblers, and is not ISO C.
 -  Remove syntactic support for [*] array declarators, which was introduced in 3.15 (https://github.com/AbsInt/CompCert/pull/539). They are usable only with variable-length arrays, which CompCert doesn't support.
 -  Check that [static <size>] declarators occur only in function prototypes and only in outermost position, as prescribed by ISO C.
 -  Fix corner case of designated initializers involving union with anonymous members.
 -  Fix wrong lexing of #pragma directives that immediately follow a // single-line comment. (Affects only non-preprocessed .i input files; preprocessed .c files are not affected.)

Usability

 -  Added warning dollar-in-identifier-extension for identifiers that contain $ signs. (This is not ISO C, just a popular extension.)
 -  Revised handling of unknown warnings: -W<unknown warning> is now a warning instead of an error; -Wno-<unknown warning> is silently ignored (https://github.com/AbsInt/CompCert/pull/554).
 -  Added warning unknown-warning-option, so that warnings about unknown warnings can be ignored (-Wno-unknown-warning-option) or turned into an error (-Werror=unknown-warning-option) (https://github.com/AbsInt/CompCert/pull/554).
 -  Recognize option -shared and pass it to the linker.
 -  Recognize options -pie and -no-pie and pass them to the linker.
 -  Recognize options -MD and -MMD and pass them to the preprocessor.
 -  On BSD platforms, use cc instead of gcc as the default preprocessor and linker.
 -  On BSD platforms, add -z nobtcfi linker option. (This turns IBT/BTI off on OpenBSD, until it is properly supported by CompCert.)

Rocq/Coq development

 -  Support Coq 8.21 (https://github.com/AbsInt/CompCert/pull/545)
 -  Support Rocq 9.0 (using the coq compatibility command) (https://github.com/AbsInt/CompCert/pull/547)
 -  Earliest version supported is now Coq 8.15.
 -  Updated vendored Flocq to version 4.2.1
 - 