### PR TITLE
Package coq-menhirlib.20250912

### DIFF
--- a/released/packages/coq-menhirlib/coq-menhirlib.20250912/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20250912/opam
@@ -1,0 +1,35 @@
+
+opam-version: "2.0"
+synopsis: "A support library for verified Coq parsers produced by Menhir"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "Jacques-Henri Jourdan <jacques-henri.jourdan@lri.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/coq-menhirlib"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
+bug-reports: "https://gitlab.inria.fr/fpottier/menhir/-/issues"
+license: "LGPL-3.0-or-later"
+build: [
+  [make "-C" "coq-menhirlib" "-j%{jobs}%"]
+]
+install: [
+  [make "-C" "coq-menhirlib" "install"]
+]
+depends: [
+  "coq" { >= "8.7" }
+]
+conflicts: [
+  "menhir" { != version }
+]
+tags: [
+  "date:2025-09-12"
+  "logpath:MenhirLib"
+]
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/menhir/-/archive/20250912/archive.tar.gz"
+  checksum: [
+    "md5=b8f83df02226419f99e49f1b637dcb11"
+    "sha512=72c85ec63104d6a7c7b6305b4642b86909fcad2e46561427ad596e37e686b3c94cd382da440f058d32800a15b157b80a8242df8043440a209ba73d209657ea84"
+  ]
+}


### PR DESCRIPTION
### `coq-menhirlib.20250912`
A support library for verified Coq parsers produced by Menhir



---
* Homepage: https://gitlab.inria.fr/fpottier/coq-menhirlib
* Source repo: git+https://gitlab.inria.fr/fpottier/menhir.git
* Bug tracker: https://gitlab.inria.fr/fpottier/menhir/-/issues

---
:camel: Pull-request generated by opam-publish v2.5.0