### PR TITLE
Package rocq-navi.0.3.1

### DIFF
--- a/released/packages/rocq-navi/rocq-navi.0.3.1/opam
+++ b/released/packages/rocq-navi/rocq-navi.0.3.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Yoshihiro Imai<y.imai@aist.go.jp>"
+
+homepage: "https://github.com/affeldt-aist/rocqnavi"
+dev-repo: "git+https://github.com/yoshihiro503/rocqnavi.git"
+bug-reports: "https://github.com/affeldt-aist/rocqnavi/issues"
+
+license: "GPL-2.0-or-later"
+synopsis: "Extension of coq2html Document Generator"
+
+description: """
+Extension of coq2html Document Generator"""
+
+build: [make]
+install: [make "BINDIR=%{bin}%" "install"]
+depends: [
+  "ocaml" {>= "4.14"}
+  "ocamlfind"
+  "dune-glob" # Parsing glob syntax like "*_unnamed_mixin_*"
+]
+
+tags: [
+  "category:Tools/Document Generator"
+  "keyword:document"
+  "keyword:html"
+  "logpath:"
+]
+authors: [
+  "Xavier Leroy <xavier.leroy@college-de-france.fr>"
+  "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+  "Yoshihiro Imai <y.imai@aist.go.jp>"
+]
+url {
+  src:
+    "https://github.com/affeldt-aist/rocqnavi/archive/refs/tags/rocqnavi.0.3.1.tar.gz"
+  checksum: [
+    "md5=40b3aadc7aef01a394a2095d5b0d918c"
+    "sha512=d5c8ed4a6443994afb75306578304d24a10fe299a04b0a20a49e852e3c3ca20ad23a8511988cb5f8ec64736219ab26cd627cba749e0fe85d6494a16016099dc4"
+  ]
+}
+


### PR DESCRIPTION
### `rocq-navi.0.3.1`
Extension of coq2html Document Generator
Extension of coq2html Document Generator



---
* Homepage: https://github.com/affeldt-aist/rocqnavi
* Source repo: git+https://github.com/yoshihiro503/rocqnavi.git
* Bug tracker: https://github.com/affeldt-aist/rocqnavi/issues

---
:camel: Pull-request generated by opam-publish v2.5.1