### PR TITLE
coq-wasm.2.2.0 is compatible with Coq 9.0

### DIFF
--- a/released/packages/coq-wasm/coq-wasm.2.2.0/opam
+++ b/released/packages/coq-wasm/coq-wasm.2.2.0/opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/WasmCert/WasmCert-Coq"
 bug-reports: "https://github.com/WasmCert/WasmCert-Coq/issues"
 depends: [
   "dune" {>= "3.11"}
-  "coq" {>= "8.20" & < "8.21~"}
+  "coq" {>= "8.20" & < "9.1~"}
   "coq-compcert" {>= "3.14"}
   "coq-ext-lib" {>= "0.11.8"}
   "coq-mathcomp-ssreflect" {>= "2.4.0" & <= "2.5~"}


### PR DESCRIPTION
depends on https://github.com/rocq-prover/opam/pull/3517 being merged first