### PR TITLE
rocq-runtime.dev don't configure mandir

### DIFF
--- a/core-dev/packages/rocq-runtime/rocq-runtime.dev/opam
+++ b/core-dev/packages/rocq-runtime/rocq-runtime.dev/opam
@@ -43,7 +43,6 @@ build: [
   [ "./configure"
     "-release" # -release must be the first command line argument
     "-prefix" prefix
-    "-mandir" man
     "-libdir" "%{lib}%/coq"
     "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]


### PR DESCRIPTION
This has been a noop I guess since the move to dune, and will be removed in https://github.com/rocq-prover/rocq/pull/21101