### PR TITLE
feat(opam): add coq-coqutil.0.0.7 (tag v0.0.7) for Rocq ≥ 9.0

### DIFF
--- a/released/packages/coq-coqutil/coq-coqutil.0.0.7/opam
+++ b/released/packages/coq-coqutil/coq-coqutil.0.0.7/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+authors: [
+  "Massachusetts Institute of Technology"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/coqutil"
+bug-reports: "https://github.com/mit-plv/coqutil/issues"
+license: "MIT"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+depends: [
+  "conf-findutils" {build}
+  "coq" {>= "9.0"}
+]
+conflict-class: [
+  "coq-coqutil"
+]
+dev-repo: "git+https://github.com/mit-plv/coqutil.git"
+synopsis: "Coq library for tactics, basic definitions, sets, maps"
+description: """
+### coqutil -- Various Coq Utilities
+
+Contents:
+* [Datatypes](https://github.com/mit-plv/coqutil/tree/master/src/coqutil/Datatypes): Some utilities for existing datatypes, and new datatypes.
+* [Decidable](https://github.com/mit-plv/coqutil/blob/master/src/coqutil/Decidable.v): `BoolSpec`-based decidability typeclasses. Allows one to write `if MyType_eqb a b then ... else ...` where `MyType_eqb a b` returns a `bool`, instead of writing `if MyType_eq_dec a b then ... else ...` where `MyType_eq_dec a b` returns a `sumbool`, while still getting `a = b` and `a <> b` as hypotheses (as opposed to `MyType_eqb a b = true` and `MyType_eqb a b = false`) after destructing the `if` (need to use [`destr`](https://github.com/mit-plv/coqutil/blob/master/src/coqutil/Tactics/destr.v) instead of `destruct`). So one gets the benefits of `Sumbool` without getting its disadvantage of having to carry around proof terms, which can cause a blow-up under reduction if one is not careful.
+* [Map](https://github.com/mit-plv/coqutil/tree/master/src/coqutil/Map): A typeclass based map library allowing one to abstract over the concrete implementation of maps. The implementations have to be extensional, which excludes certain efficient implementations, but simplifies proofs, because one can `replace mapA with mapB` if one can prove that `mapA` and `mapB` have the same contents. Comes with a [solver](https://github.com/mit-plv/coqutil/blob/master/src/coqutil/Map/Solver.v) which works reasonably fast on most map goals we have encountered so far.
+* [Tactics](https://github.com/mit-plv/coqutil/tree/master/src/coqutil/Tactics): A collection of useful general-purpose tactics.
+* [Word](https://github.com/mit-plv/coqutil/tree/master/src/coqutil/Word): Fixed width words for any width, in the same typeclass based style as the map library. Designed for the case where all words have the same (potentially abstract) bit width. Therefore, it does not provide functions to concatenate and split words, which is better addressed by [bbv](https://github.com/mit-plv/bbv/).
+* [Z](https://github.com/mit-plv/coqutil/tree/master/src/coqutil/Z): Utilities to work with the `Z` type from Coq's standard library, including a tactic to prove `Z` equalities by splitting the equality into equalities on bit index ranges, a tactic to make `lia` capable of reasoning about goals with division and modulo, and a tactic to simplify expressions containing nested occurrences of `mod`, and more misc utilities.
+* Various macros, notations, and desirable default settings.
+
+Each feature is intended to be as minimal and as independent of the other features as possible, so that users can pick just what they need.
+"""
+tags: ["logpath:coqutil"]
+url {
+  src: "https://github.com/mit-plv/coqutil/archive/refs/tags/v0.0.7.tar.gz"
+  checksum: "sha512=7800c6403de65d2d090b69a5161ff16916878f06fd08627c70dfd899db94850353d1e0c6dad119ebbe7f4e72148c8b7ad834471e93f1822b232faeded512bb68"
+}


### PR DESCRIPTION
Added coq-coqutil.0.0.7 according to the package’s maintainer request ([mit-plv/coqutil#141](https://github.com/mit-plv/coqutil/issues/141))