### PR TITLE
Add `rocq-mathcomp-bigenough` and `rocq-mathcomp-finmap` to `extra-dev/`

### DIFF
--- a/extra-dev/packages/coq-mathcomp-bigenough/coq-mathcomp-bigenough.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-bigenough/coq-mathcomp-bigenough.dev/opam
@@ -2,25 +2,11 @@ opam-version: "2.0"
 maintainer: "Cyril Cohen <cyril.cohen@inria.fr>"
 
 homepage: "https://github.com/math-comp/bigenough"
+dev-repo: "git+https://github.com/math-comp/bigenough"
 bug-reports: "https://github.com/math-comp/bigenough/issues"
 license: "CeCILL-B"
-dev-repo: "git+https://github.com/math-comp/bigenough"
 
-build: [ make "-j" "%{jobs}%" "COQEXTRAFLAGS+=-native-compiler yes" {coq-native:installed & coq:version < "8.13~" } ]
-install: [ make "install" ]
-depends: [
-  "ocaml"
-  "coq-mathcomp-ssreflect" {(>= "1.6" | = "dev")}
-]
-tags: [ "keyword:bigenough" "keyword:asymptotic reasonning" "keyword:small scale reflection" "keyword:mathematical components" ]
-authors: [ "Cyril Cohen <cyril.cohen@inria.fr>" ]
-synopsis: "A small library to do epsilon - N reasonning"
-description: """
-The package contains a package to reasoning with big enough objects
-(mostly natural numbers). This package is essentially for backward
-compatibility purposes as `bigenough` will be subsumed by the near
-tactics. The formalization is based on the Mathematical Components
-library."""
-url {
-  src: "git+https://github.com/math-comp/bigenough.git#master"
-}
+depends: [ "rocq-mathcomp-bigenough" { = version } ]
+authors: [ "Cyril Cohen" ]
+
+synopsis: "Compatibility package for rocq-mathcomp-bigenough"

--- a/extra-dev/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.dev/opam
@@ -6,32 +6,10 @@ dev-repo: "git+https://github.com/math-comp/finmap.git"
 bug-reports: "https://github.com/math-comp/finmap/issues"
 license: "CECILL-B"
 
-synopsis: "Finite sets, finite maps, finitely supported functions"
-description: """
-This library is an extension of mathematical component in order to
-support finite sets and finite maps on choicetypes (rather that finite
-types). This includes support for functions with finite support and
-multisets. The library also contains a generic order and set libary,
-which will be used to subsume notations for finite sets, eventually."""
-
-build: [make "-j%{jobs}%"]
-install: [make "install"]
-depends: [
-  ("coq" {>= "8.18" & < "8.21~"}
-  | "rocq-core" {>= "9.0" | = "dev"})
-  "coq-mathcomp-ssreflect" { >= "2.0" | = "dev" }
-]
-
-tags: [
-  "keyword:finmap"
-  "keyword:finset"
-  "keyword:multiset"
-  "logpath:mathcomp.finmap"
-]
+depends: [ "rocq-mathcomp-finmap" { = version } ]
 authors: [
   "Cyril Cohen"
   "Kazuhiko Sakaguchi"
 ]
-url {
-  src: "git+https://github.com/math-comp/finmap.git#master"
-}
+
+synopsis: "Compatibility package for rocq-mathcomp-finmap"

--- a/extra-dev/packages/rocq-mathcomp-bigenough/rocq-mathcomp-bigenough.dev/opam
+++ b/extra-dev/packages/rocq-mathcomp-bigenough/rocq-mathcomp-bigenough.dev/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Cyril Cohen <cyril.cohen@inria.fr>"
+
+homepage: "https://github.com/math-comp/bigenough"
+dev-repo: "git+https://github.com/math-comp/bigenough.git"
+bug-reports: "https://github.com/math-comp/bigenough/issues"
+license: "CeCILL-B"
+
+synopsis: "A small library to do epsilon - N reasoning"
+description: """
+The package contains a package to reasoning with big enough objects
+(mostly natural numbers). This package is essentially for backward
+compatibility purposes as `bigenough` will be subsumed by the near
+tactics. The formalization is based on the Mathematical Components
+library."""
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+depends: [
+  ("coq" {>= "8.10" & < "8.21~"}
+  | "rocq-core" {>= "9.0"})
+  ("coq-mathcomp-ssreflect" {>= "1.6" & <= "2.4"}
+  |"rocq-mathcomp-boot" {>= "2.5"})
+]
+conflicts: [ "coq-mathcomp-bigenough" { != version } ]
+
+tags: [
+  "keyword:bigenough"
+  "keyword:asymptotic reasonning"
+  "keyword:small scale reflection"
+  "keyword:mathematical components"
+  "logpath:mathcomp.bigenough"
+]
+authors: [
+  "Cyril Cohen"
+]
+url {
+  src: "git+https://github.com/math-comp/bigenough.git#master"
+}

--- a/extra-dev/packages/rocq-mathcomp-finmap/rocq-mathcomp-finmap.dev/opam
+++ b/extra-dev/packages/rocq-mathcomp-finmap/rocq-mathcomp-finmap.dev/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Cyril Cohen <cyril.cohen@inria.fr>"
+
+homepage: "https://github.com/math-comp/finmap"
+dev-repo: "git+https://github.com/math-comp/finmap.git"
+bug-reports: "https://github.com/math-comp/finmap/issues"
+license: "CECILL-B"
+
+synopsis: "Finite sets, finite maps, finitely supported functions"
+description: """
+This library is an extension of mathematical component in order to
+support finite sets and finite maps on choicetypes (rather that finite
+types). This includes support for functions with finite support and
+multisets. The library also contains a generic order and set libary,
+which will be used to subsume notations for finite sets, eventually."""
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+depends: [
+  ("coq" {>= "8.20" & < "8.21~"}
+  | "rocq-core" {>= "9.0"})
+  ("coq-mathcomp-ssreflect" { >= "2.2" & < "2.4~" }
+  |"rocq-mathcomp-ssreflect" { >= "2.4" })
+]
+conflicts: [ "coq-mathcomp-finmap" { != version } ]
+
+tags: [
+  "keyword:finmap"
+  "keyword:finset"
+  "keyword:multiset"
+  "logpath:mathcomp.finmap"
+]
+authors: [
+  "Cyril Cohen"
+  "Kazuhiko Sakaguchi"
+]
+url {
+  src: "git+https://github.com/math-comp/finmap.git#master"
+}


### PR DESCRIPTION
These packages have been renamed in `released` a while ago, but not in `extra-dev`.

The contents of new opam files are based on those in the `bigenough` and `finmap` repositories.

Ping @CohenCyril (the author/maintainer of these two packages)