### PR TITLE
Update mathcomp-dioid dev dependencies

### DIFF
--- a/extra-dev/packages/coq-mathcomp-dioid/coq-mathcomp-dioid.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-dioid/coq-mathcomp-dioid.dev/opam
@@ -14,10 +14,10 @@ build: [
 install: [make "install"]
 
 depends: [
-  "coq" { >= "8.11" & < "8.14~" }
-  "coq-mathcomp-ssreflect" { >= "1.12" & < "1.13~" }
-  "coq-mathcomp-analysis" { >= "0.3.5" & < "0.4~" }
-  "coq-hierarchy-builder" { >= "1.0" & < "2~" }
+  "coq" { >= "9.4~" }
+  "coq-mathcomp-algebra" { >= "2.4~" }
+  "coq-mathcomp-classical" { >= "1.8" }
+  "coq-hierarchy-builder" { >= "1.8.0" }
 ]
 synopsis: "Dioid"
 description: """


### PR DESCRIPTION
The `coq-mathcomp-dioid.dev` metadata describes the old Coq 8.13 / MathComp 1.x implementation, so current development switches reject it and may fall back to the incompatible 0.1 release when constraints are ignored. Upstream Dioid master has moved to Hierarchy Builder and the split MathComp package hierarchy; this updates the dev dependencies to match that implementation and [math-comp/dioid#1](https://github.com/math-comp/dioid/pull/1).

The source remains the upstream `math-comp/dioid` master branch, not the theorem-labs fork. This draft must not merge until the upstream compatibility PR lands.

`opam lint` passes without warnings, and the upstream compatibility branch builds completely against `rocq-dev-testing` with `make -j4`.

The remaining red build is expected because upstream `math-comp/dioid#master` does not yet carry the migration. `complete_lattice.v` fails with:

```
Error: Usage: HB.mixin Record <MixinName> T & F A & … := { … }.
```

The `T & F T` binder syntax is core Rocq grammar from rocq-prover/rocq#21611 (merged 2026-02-26, first tagged in 9.3+rc1), replacing ssreflect's `T of F T`. `Packages that can never be installed:` is empty, so the solver is satisfied and only the source is stale. `ci-skip` remains until math-comp/dioid#1 merges.

ci-skip: coq-mathcomp-dioid

> *Authorship note: this was researched and written by an AI coding agent
> (OpenAI Codex), working on Jason Gross's behalf; Jason reviews what is
> posted from this account.*

Wordsmithed by Codex.
