### PR TITLE
iris, std++: use github mirror

### DIFF
--- a/released/packages/rocq-iris-heap-lang/rocq-iris-heap-lang.4.5.0/opam
+++ b/released/packages/rocq-iris-heap-lang/rocq-iris-heap-lang.4.5.0/opam
@@ -25,7 +25,7 @@ install: ["./make-package" "iris_heap_lang" "install"]
 
 url {
   src:
-    "https://gitlab.mpi-sws.org/iris/iris/-/archive/iris-4.5.0.tar.gz"
+    "https://github.com/rocq-iris/iris/archive/refs/tags/iris-4.5.0.tar.gz"
   checksum:
-    "sha512=ef80fe54729b0f9471415ec32b5a78e26f73459e0ea9a2056b13a9590820a6accf878b6c414081d066b1a4cebaaf8546e61276e3c5356eceb92a1d689accabe7"
+    "sha512=f72c7fb4f3f21cbad129fc2bab1974067dfd59a947009840598c614c079f0bce472a8dc3caa2e6c877634d3f24cd2611ddc75d6981af3ebbdf277ce336282151"
 }

--- a/released/packages/rocq-iris/rocq-iris.4.5.0/opam
+++ b/released/packages/rocq-iris/rocq-iris.4.5.0/opam
@@ -40,7 +40,7 @@ install: ["./make-package" "iris" "install"]
 
 url {
   src:
-    "https://gitlab.mpi-sws.org/iris/iris/-/archive/iris-4.5.0.tar.gz"
+    "https://github.com/rocq-iris/iris/archive/refs/tags/iris-4.5.0.tar.gz"
   checksum:
-    "sha512=ef80fe54729b0f9471415ec32b5a78e26f73459e0ea9a2056b13a9590820a6accf878b6c414081d066b1a4cebaaf8546e61276e3c5356eceb92a1d689accabe7"
+    "sha512=f72c7fb4f3f21cbad129fc2bab1974067dfd59a947009840598c614c079f0bce472a8dc3caa2e6c877634d3f24cd2611ddc75d6981af3ebbdf277ce336282151"
 }

--- a/released/packages/rocq-stdpp-bitvector/rocq-stdpp-bitvector.1.13.0/opam
+++ b/released/packages/rocq-stdpp-bitvector/rocq-stdpp-bitvector.1.13.0/opam
@@ -27,7 +27,7 @@ install: ["./make-package" "stdpp_bitvector" "install"]
 
 url {
   src:
-    "https://gitlab.mpi-sws.org/iris/stdpp/-/archive/stdpp-1.13.0.tar.gz"
+    "https://github.com/rocq-iris/stdpp/archive/refs/tags/stdpp-1.13.0.tar.gz"
   checksum:
-    "sha512=ba0477e0a7f3adea3baf726133294171724e57de107bd79d397392881ee9093f8055334958fdf9db6c3b72a99763510c8e9b4e6eca51dbe0c5676fd6f5a78a73"
+    "sha512=90ea028ab46043c97e362ec83b2fa8f9b6e209f60264385bddf16856d7b2cfa1072e7013e8cc055651b9370f86729cdbee04b105f394e366090c248f5a70f07a"
 }

--- a/released/packages/rocq-stdpp/rocq-stdpp.1.13.0/opam
+++ b/released/packages/rocq-stdpp/rocq-stdpp.1.13.0/opam
@@ -45,7 +45,7 @@ install: ["./make-package" "stdpp" "install"]
 
 url {
   src:
-    "https://gitlab.mpi-sws.org/iris/stdpp/-/archive/stdpp-1.13.0.tar.gz"
+    "https://github.com/rocq-iris/stdpp/archive/refs/tags/stdpp-1.13.0.tar.gz"
   checksum:
-    "sha512=ba0477e0a7f3adea3baf726133294171724e57de107bd79d397392881ee9093f8055334958fdf9db6c3b72a99763510c8e9b4e6eca51dbe0c5676fd6f5a78a73"
+    "sha512=90ea028ab46043c97e362ec83b2fa8f9b6e209f60264385bddf16856d7b2cfa1072e7013e8cc055651b9370f86729cdbee04b105f394e366090c248f5a70f07a"
 }


### PR DESCRIPTION
MPI's gitlab server is buckling under the load of aggressive scrapers which are likely fueled by the global craze for LLMs. We had to install aggressive rate limiting, and we're using github as a mirror for less rate-limited anonymous downloads.

The packages contents should be the same but the checksums change because they depend on the exact heuristics used during compression.