### PR TITLE
extra-dev: dev recipes for 13 packages whose release cap is stale

### DIFF
--- a/extra-dev/packages/coq-bits/coq-bits.dev/opam
+++ b/extra-dev/packages/coq-bits/coq-bits.dev/opam
@@ -17,7 +17,7 @@ axiomatization and extraction to OCaml native integers."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.16"}
+  "coq" {= "dev"}
   "ocamlbuild" 
   "coq-mathcomp-algebra" {>= "2.0"}
   "coq-mathcomp-algebra-tactics"

--- a/extra-dev/packages/coq-bits/coq-bits.dev/opam
+++ b/extra-dev/packages/coq-bits/coq-bits.dev/opam
@@ -19,7 +19,7 @@ install: [make "install"]
 depends: [
   "coq" {= "dev"}
   "ocamlbuild" 
-  "coq-mathcomp-algebra" {>= "2.0"}
+  "coq-mathcomp-algebra" {= "dev"}
   "coq-mathcomp-algebra-tactics"
 ]
 

--- a/extra-dev/packages/coq-bits/coq-bits.dev/opam
+++ b/extra-dev/packages/coq-bits/coq-bits.dev/opam
@@ -1,0 +1,42 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "anton.a.trunov@gmail.com"
+
+homepage: "https://github.com/coq-community/bits"
+dev-repo: "git+https://github.com/coq-community/bits.git"
+bug-reports: "https://github.com/coq-community/bits/issues"
+license: "Apache-2.0"
+
+synopsis: "Coq bit vector library"
+description: """
+A formalization of bitset operations in Coq with a corresponding
+axiomatization and extraction to OCaml native integers."""
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+depends: [
+  "coq" {>= "8.16"}
+  "ocamlbuild" 
+  "coq-mathcomp-algebra" {>= "2.0"}
+  "coq-mathcomp-algebra-tactics"
+]
+
+tags: [
+  "category:Computer Science/Data Types and Data Structures"
+  "keyword:bit arithmetic"
+  "keyword:bitset"
+  "keyword:bit vector"
+  "keyword:extraction"
+  "logpath:Bits"
+]
+authors: [
+  "Andrew Kennedy <akenn@microsoft.com>"
+  "Arthur Blot <arthur.blot@ens-lyon.fr>"
+  "Pierre-Évariste Dagand <pierre-evariste.dagand@lip6.fr>"
+]
+
+url {
+  src: "git+https://github.com/rocq-community/bits.git#master"
+}

--- a/extra-dev/packages/coq-cds4ltl/coq-cds4ltl.dev/opam
+++ b/extra-dev/packages/coq-cds4ltl/coq-cds4ltl.dev/opam
@@ -15,8 +15,8 @@ paper: A Calculational Deductive System for Linear Temporal Logic (CDS4LTL).
 build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
-  "rocq-core" {>= "9.1"}
-  "rocq-stdlib" {>= "9.1"}
+  "rocq-core" {= "dev"}
+  "rocq-stdlib" {= "dev"}
 ]
 
 tags: [

--- a/extra-dev/packages/coq-cds4ltl/coq-cds4ltl.dev/opam
+++ b/extra-dev/packages/coq-cds4ltl/coq-cds4ltl.dev/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "johnw@newartisans.com"
+
+homepage: "https://github.com/jwiegley/coq-cds4ltl"
+dev-repo: "git+https://github.com/jwiegley/coq-cds4ltl.git"
+bug-reports: "https://github.com/jwiegley/coq-cds4ltl/issues"
+license: "BSD-3-Clause"
+
+synopsis: "A Calculational Deductive System for Linear Temporal Logic"
+description: """
+An axiomatic and denotational formalization of the theorems described by the
+paper: A Calculational Deductive System for Linear Temporal Logic (CDS4LTL).
+"""
+
+build: [make "-j%{jobs}%" ]
+install: [make "install"]
+depends: [
+  "rocq-core" {>= "9.1"}
+  "rocq-stdlib" {>= "9.1"}
+]
+
+tags: [
+  "keyword: temporal logic"
+  "category: Mathematics/Logic/Modal logic"
+  "logpath: CDS4LTL"
+]
+authors: [
+  "John Wiegley"
+]
+
+url {
+  src: "git+https://github.com/jwiegley/coq-cds4ltl.git#master"
+}

--- a/extra-dev/packages/coq-comp-dec-modal/coq-comp-dec-modal.dev/opam
+++ b/extra-dev/packages/coq-comp-dec-modal/coq-comp-dec-modal.dev/opam
@@ -1,0 +1,55 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "christian.doczkal@inria.fr"
+
+homepage: "https://github.com/coq-community/comp-dec-modal"
+dev-repo: "git+https://github.com/coq-community/comp-dec-modal.git"
+bug-reports: "https://github.com/coq-community/comp-dec-modal/issues"
+doc: "https://coq-community.github.io/comp-dec-modal/"
+license: "CECILL-B"
+
+synopsis: "Constructive proofs of soundness and completeness for K, K*, CTL, PDL, and PDL with converse"
+description: """
+This project presents machine-checked constructive proofs of
+soundness, completeness, decidability, and the small-model property
+for the logics K, K*, CTL, and PDL (with and without converse).
+
+For all considered logics, we prove soundness and completeness of
+their respective Hilbert-style axiomatization. For K, K*, and CTL,
+we also prove soundness and completeness for Gentzen systems (i.e.,
+sequent calculi).
+
+For each logic, the central construction is a pruning-based
+algorithm computing for a given formula either a satisfying model of
+bounded size or a proof of its negation. The completeness and
+decidability results then follow with soundness from the existence
+of said algorithm.
+  """
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+depends: [
+  "coq" {>= "8.16"}
+  "coq-mathcomp-ssreflect" {>= "2.0"}
+  "coq-hierarchy-builder" {>= "1.6.0"}
+]
+
+tags: [
+  "category:Mathematics/Logic/Modal logic"
+  "keyword:modal logic"
+  "keyword:completeness"
+  "keyword:decidability"
+  "keyword:Hilbert system"
+  "keyword:computation tree logic"
+  "keyword:propositional dynamic logic"
+  "logpath:CompDecModal"
+]
+authors: [
+  "Christian Doczkal"
+]
+
+url {
+  src: "git+https://github.com/rocq-community/comp-dec-modal.git#master"
+}

--- a/extra-dev/packages/coq-comp-dec-modal/coq-comp-dec-modal.dev/opam
+++ b/extra-dev/packages/coq-comp-dec-modal/coq-comp-dec-modal.dev/opam
@@ -31,7 +31,7 @@ of said algorithm.
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.16"}
+  "coq" {= "dev"}
   "coq-mathcomp-ssreflect" {>= "2.0"}
   "coq-hierarchy-builder" {>= "1.6.0"}
 ]

--- a/extra-dev/packages/coq-coqtail/coq-coqtail.dev/opam
+++ b/extra-dev/packages/coq-coqtail/coq-coqtail.dev/opam
@@ -1,0 +1,41 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/coqtail-math"
+dev-repo: "git+https://github.com/coq-community/coqtail-math.git"
+bug-reports: "https://github.com/coq-community/coqtail-math/issues"
+license: "LGPL-3.0-only"
+
+synopsis: "Library of mathematical theorems and tools proved inside the Coq"
+description: """
+Coqtail is a library of mathematical theorems and tools proved inside
+the Coq proof assistant. Results range mostly from arithmetic to real
+and complex analysis."""
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+depends: [
+  "coq" {>= "8.17"}
+]
+
+tags: [
+  "category:Mathematics/Real Calculus and Topology"
+  "keyword:real analysis"
+  "keyword:complex analysis"
+  "logpath:Coqtail"
+]
+authors: [
+  "Guillaume Allais"
+  "Sylvain Dailler"
+  "Hugo Férée"
+  "Jean-Marie Madiot"
+  "Pierre-Marie Pédrot"
+  "Amaury Pouly"
+]
+
+url {
+  src: "git+https://github.com/rocq-community/coqtail-math.git#master"
+}

--- a/extra-dev/packages/coq-coqtail/coq-coqtail.dev/opam
+++ b/extra-dev/packages/coq-coqtail/coq-coqtail.dev/opam
@@ -18,7 +18,7 @@ and complex analysis."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.17"}
+  "coq" {= "dev"}
 ]
 
 tags: [

--- a/extra-dev/packages/coq-exact-real-arithmetic/coq-exact-real-arithmetic.dev/opam
+++ b/extra-dev/packages/coq-exact-real-arithmetic/coq-exact-real-arithmetic.dev/opam
@@ -6,7 +6,7 @@ build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
   "ocaml"
-  "coq" {>= "8.10"}
+  "coq" {= "dev"}
 ]
 tags: [
   "keyword: correctness"

--- a/extra-dev/packages/coq-exact-real-arithmetic/coq-exact-real-arithmetic.dev/opam
+++ b/extra-dev/packages/coq-exact-real-arithmetic/coq-exact-real-arithmetic.dev/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Hugo.Herbelin@inria.fr"
+homepage: "https://github.com/rocq-community/exact-real-arithmetic"
+license: "LGPL 2.1"
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+depends: [
+  "ocaml"
+  "coq" {>= "8.10"}
+]
+tags: [
+  "keyword: correctness"
+  "keyword: real numbers"
+  "keyword: arithmetic"
+  "category: Mathematics/Real Numbers"
+]
+authors: [
+  "Jérôme Creci"
+]
+bug-reports: "https://github.com/rocq-community/exact-real-arithmetic/issues"
+dev-repo: "git+https://github.com/rocq-community/exact-real-arithmetic.git"
+synopsis: "Exact Real Arithmetic"
+description: """
+This contribution contains a proof of correctness
+of some exact real arithmetic algorithms from the PhD thesis of
+Valérie Ménissier-Morain"""
+
+url {
+  src: "git+https://github.com/rocq-community/exact-real-arithmetic.git#master"
+}

--- a/extra-dev/packages/coq-hanoi/coq-hanoi.dev/opam
+++ b/extra-dev/packages/coq-hanoi/coq-hanoi.dev/opam
@@ -40,7 +40,7 @@ An interactive version of the library is available
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "9.1")}
+  "coq" {= "dev"}
   "rocq-mathcomp-ssreflect" {(>= "2.5.0")}
   "rocq-mathcomp-algebra" {(>= "2.5.0")}
   "coq-mathcomp-finmap" {(>= "2.2.2")}

--- a/extra-dev/packages/coq-hanoi/coq-hanoi.dev/opam
+++ b/extra-dev/packages/coq-hanoi/coq-hanoi.dev/opam
@@ -1,0 +1,59 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "thery@sophia.inria.fr"
+
+homepage: "https://github.com/thery/hanoi"
+dev-repo: "git+https://github.com/thery/hanoi.git"
+bug-reports: "https://github.com/thery/hanoi/issues"
+license: "MIT"
+
+synopsis: "Hanoi tower in Rocq"
+description: """
+Hanoi tower in Rocq
+
+
+| File                              |  Content                                 | 
+| --------------------------------- | -----------------------------------------| 
+| [extra](./extra.v)                | Extra theorems from the standard library |
+| [gdist](./gdist.v)                | Distance in a graph                      |
+| [ghanoi](./ghanoi.v)              | General Hanoi framework                  |
+| [ghanoi3](./ghanoi3.v)            | General Hanoi framework with 3 pegs      |
+| [lhanoi3](./lhanoi3.v)            | Linear Hanoi tower with 3 pegs           |
+| [rhanoi3](./rhanoi3.v)            | Regular Hanoi tower with 3 pegs          |
+| [triangular](./triangular.v)      | Theorems about triangular numbers        |
+| [phi](./phi.v)                    | Theorems about the Φ function            |
+| [psi](./psi.v)                    | Theorems about the Ψ function            |
+| [ghanoi4](./ghanoi4.v)            | General Hanoi framework with 4 pegs      |
+| [rhanoi4](./rhanoi4.v)            | Regular Hanoi tower with 4 pegs          |
+| [star](./star.v)                  | Some maths for the shanoi                |
+| [shanoi](./shanoi.v)              | Hanoi tower in star                      |
+| [shanoi4](./shanoi4.v)            | Hanoi tower with 4 pegs in star          |
+
+A note about this development is available 
+[here](https://hal.inria.fr/hal-02903548).
+
+An interactive version of the library is available 
+[here](https://thery.github.io/hanoi/index.html)."""
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+depends: [
+  "coq" {(>= "9.1")}
+  "rocq-mathcomp-ssreflect" {(>= "2.5.0")}
+  "rocq-mathcomp-algebra" {(>= "2.5.0")}
+  "coq-mathcomp-finmap" {(>= "2.2.2")}
+]
+
+tags: [
+  "keyword:hanoi tower"
+  "logpath:hanoi"
+]
+authors: [
+  "Laurent Théry"
+]
+
+url {
+  src: "git+https://github.com/thery/hanoi.git#master"
+}

--- a/extra-dev/packages/coq-mathcomp-abel/coq-mathcomp-abel.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-abel/coq-mathcomp-abel.dev/opam
@@ -21,12 +21,12 @@ build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
   "rocq-core" {= "dev"}
-  "coq-mathcomp-ssreflect" {>= "2.4"}
+  "coq-mathcomp-ssreflect" {= "dev"}
   "coq-mathcomp-fingroup" 
   "coq-mathcomp-algebra" 
   "coq-mathcomp-solvable" 
   "coq-mathcomp-field" 
-  "coq-mathcomp-real-closed" 
+  "coq-mathcomp-real-closed" {= "dev"}
 ]
 
 tags: [

--- a/extra-dev/packages/coq-mathcomp-abel/coq-mathcomp-abel.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-abel/coq-mathcomp-abel.dev/opam
@@ -20,7 +20,7 @@ Mathematical Components library."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "rocq-core" {>= "9.0"}
+  "rocq-core" {= "dev"}
   "coq-mathcomp-ssreflect" {>= "2.4"}
   "coq-mathcomp-fingroup" 
   "coq-mathcomp-algebra" 

--- a/extra-dev/packages/coq-mathcomp-abel/coq-mathcomp-abel.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-abel/coq-mathcomp-abel.dev/opam
@@ -1,0 +1,48 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "Cyril Cohen <cyril.cohen@inria.fr>"
+
+homepage: "https://github.com/math-comp/abel"
+dev-repo: "git+https://github.com/math-comp/abel.git"
+bug-reports: "https://github.com/math-comp/abel/issues"
+license: "CECILL-B"
+
+synopsis: "Abel - Ruffini's theorem"
+description: """
+This repository contains a proof of Abel - Galois Theorem
+(equivalence between being solvable by radicals and having a
+solvable Galois group) and Abel - Ruffini Theorem (unsolvability of
+quintic equations) in the Coq proof-assistant and using the
+Mathematical Components library."""
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+depends: [
+  "rocq-core" {>= "9.0"}
+  "coq-mathcomp-ssreflect" {>= "2.4"}
+  "coq-mathcomp-fingroup" 
+  "coq-mathcomp-algebra" 
+  "coq-mathcomp-solvable" 
+  "coq-mathcomp-field" 
+  "coq-mathcomp-real-closed" 
+]
+
+tags: [
+  "keyword:algebra"
+  "keyword:Galois"
+  "keyword:Abel Ruffini"
+  "keyword:unsolvability of quintincs"
+  "logpath:Abel"
+]
+authors: [
+  "Sophie Bernard"
+  "Cyril Cohen"
+  "Assia Mahboubi"
+  "Pierre-Yves Strub"
+]
+
+url {
+  src: "git+https://github.com/math-comp/abel.git#master"
+}

--- a/extra-dev/packages/coq-mathcomp-apery/coq-mathcomp-apery.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-apery/coq-mathcomp-apery.dev/opam
@@ -23,12 +23,12 @@ build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
   "coq" {= "dev"}
-  "coq-mathcomp-ssreflect" {>= "2.4"}
+  "coq-mathcomp-ssreflect" {= "dev"}
   "coq-mathcomp-algebra" 
   "coq-mathcomp-field" 
   "coq-coqeal" {>= "2.1.0"}
-  "coq-mathcomp-real-closed" 
-  "coq-mathcomp-bigenough" {>= "1.0.1"}
+  "coq-mathcomp-real-closed" {= "dev"}
+  "coq-mathcomp-bigenough" {= "dev"}
   "coq-mathcomp-zify" 
   "coq-mathcomp-algebra-tactics" 
 ]

--- a/extra-dev/packages/coq-mathcomp-apery/coq-mathcomp-apery.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-apery/coq-mathcomp-apery.dev/opam
@@ -1,0 +1,51 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "assia.mahboubi@inria.fr"
+
+homepage: "https://github.com/coq-community/apery"
+dev-repo: "git+https://github.com/coq-community/apery.git"
+bug-reports: "https://github.com/coq-community/apery/issues"
+license: "CECILL-C"
+
+synopsis: "A formally verified proof in Coq, by computer algebra, that ζ(3) is irrational"
+description: """
+This project contains a formal proof that the real number ζ(3),
+also known as Apéry's constant, is irrational. It follows roughly
+Apéry's original sketch of a proof. However, the recurrence
+relations constituting the crux of the proof have been guessed by a
+computer algebra program (in this case in Maple/Algolib). These
+relations are formally checked a posteriori, so that Coq's kernel
+remains the sole trusted code base."""
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+depends: [
+  "coq" {>= "8.20"}
+  "coq-mathcomp-ssreflect" {>= "2.4"}
+  "coq-mathcomp-algebra" 
+  "coq-mathcomp-field" 
+  "coq-coqeal" {>= "2.1.0"}
+  "coq-mathcomp-real-closed" 
+  "coq-mathcomp-bigenough" {>= "1.0.1"}
+  "coq-mathcomp-zify" 
+  "coq-mathcomp-algebra-tactics" 
+]
+
+tags: [
+  "category:Mathematics/Arithmetic and Number Theory/Number theory"
+  "keyword:apery recurrence"
+  "keyword:irrationality"
+  "keyword:creative telescoping"
+  "logpath:mathcomp.apery"
+]
+authors: [
+  "Frédéric Chyzak"
+  "Assia Mahboubi"
+  "Thomas Sibut-Pinote"
+]
+
+url {
+  src: "git+https://github.com/rocq-community/apery.git#master"
+}

--- a/extra-dev/packages/coq-mathcomp-apery/coq-mathcomp-apery.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-apery/coq-mathcomp-apery.dev/opam
@@ -22,7 +22,7 @@ remains the sole trusted code base."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.20"}
+  "coq" {= "dev"}
   "coq-mathcomp-ssreflect" {>= "2.4"}
   "coq-mathcomp-algebra" 
   "coq-mathcomp-field" 

--- a/extra-dev/packages/coq-mmaps/coq-mmaps.dev/opam
+++ b/extra-dev/packages/coq-mmaps/coq-mmaps.dev/opam
@@ -20,7 +20,7 @@ that is meant to complement the Stdlib's MSet library."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.16"}
+  "coq" {= "dev"}
 ]
 
 tags: [

--- a/extra-dev/packages/coq-mmaps/coq-mmaps.dev/opam
+++ b/extra-dev/packages/coq-mmaps/coq-mmaps.dev/opam
@@ -1,0 +1,41 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/coq-mmaps"
+dev-repo: "git+https://github.com/coq-community/coq-mmaps.git"
+bug-reports: "https://github.com/coq-community/coq-mmaps/issues"
+license: "LGPL-2.1-only"
+
+synopsis: "Several implementations of finite maps over arbitrary ordered types using Coq functors"
+description: """
+This project contains several implementations of finite maps,
+including implementations based on AVL trees and red-black trees.
+The finite maps are parameterized on arbitrary ordered types using
+Coq functors. This is an updated version of the Coq Stdlib's FMaps
+that is meant to complement the Stdlib's MSet library."""
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+depends: [
+  "coq" {>= "8.16"}
+]
+
+tags: [
+  "category:Computer Science/Data Types and Data Structures"
+  "keyword:finite maps"
+  "keyword:red-black trees"
+  "keyword:AVL trees"
+  "keyword:ordered types"
+  "logpath:MMaps"
+]
+authors: [
+  "Pierre Letouzey"
+  "Andrew W. Appel"
+]
+
+url {
+  src: "git+https://github.com/rocq-community/mmaps.git#master"
+}

--- a/extra-dev/packages/coq-stalmarck-tactic/coq-stalmarck-tactic.dev/opam
+++ b/extra-dev/packages/coq-stalmarck-tactic/coq-stalmarck-tactic.dev/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/stalmarck"
+dev-repo: "git+https://github.com/coq-community/stalmarck.git"
+bug-reports: "https://github.com/coq-community/stalmarck/issues"
+license: "LGPL-2.1-or-later"
+
+synopsis: "Coq tactic and verified tool for proving tautologies using Stålmarck's algorithm"
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" {>= "4.09.0"}
+  "dune" {>= "2.8"}
+  "coq" {= "dev"}
+  "coq-stalmarck" {= version}
+]
+
+tags: [
+  "category:Miscellaneous/Coq Extensions"
+  "category:Miscellaneous/Extracted Programs/Decision procedures"
+  "keyword:boolean formula"
+  "keyword:tautology checker"
+  "keyword:tactics"
+  "logpath:Stalmarck.Tactic"
+]
+authors: [
+  "Pierre Letouzey"
+  "Laurent Théry"
+]
+
+url {
+  src: "git+https://github.com/rocq-community/stalmarck.git#master"
+}

--- a/extra-dev/packages/coq-stalmarck-tactic/coq-stalmarck-tactic.dev/opam
+++ b/extra-dev/packages/coq-stalmarck-tactic/coq-stalmarck-tactic.dev/opam
@@ -11,7 +11,7 @@ synopsis: "Coq tactic and verified tool for proving tautologies using Stålmarck
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.09.0"}
-  "dune" {>= "2.8"}
+  "dune" {>= "2.8" & < "3.24"}
   "coq" {= "dev"}
   "coq-stalmarck" {= version}
 ]

--- a/extra-dev/packages/coq-stalmarck/coq-stalmarck.dev/opam
+++ b/extra-dev/packages/coq-stalmarck/coq-stalmarck.dev/opam
@@ -1,0 +1,36 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/stalmarck"
+dev-repo: "git+https://github.com/coq-community/stalmarck.git"
+bug-reports: "https://github.com/coq-community/stalmarck/issues"
+license: "LGPL-2.1-or-later"
+
+synopsis: "Verified implementation of Stålmarck's algorithm for proving tautologies in Coq"
+description: """
+A two-level approach to prove tautologies using Stålmarck's
+algorithm in Coq."""
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+depends: [
+  "coq" {= "dev"}
+]
+
+tags: [
+  "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures"
+  "keyword:boolean formula"
+  "keyword:tautology checker"
+  "logpath:Stalmarck.Algorithm"
+]
+authors: [
+  "Pierre Letouzey"
+  "Laurent Théry"
+]
+
+url {
+  src: "git+https://github.com/rocq-community/stalmarck.git#master"
+}

--- a/extra-dev/packages/coq-sum-of-two-square/coq-sum-of-two-square.dev/opam
+++ b/extra-dev/packages/coq-sum-of-two-square/coq-sum-of-two-square.dev/opam
@@ -29,7 +29,7 @@ Laurent Thery thery@sophia.inria.fr"""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" 
+  "coq" {= "dev"}
 ]
 
 tags: [

--- a/extra-dev/packages/coq-sum-of-two-square/coq-sum-of-two-square.dev/opam
+++ b/extra-dev/packages/coq-sum-of-two-square/coq-sum-of-two-square.dev/opam
@@ -1,0 +1,45 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "thery@sophia.inria.fr"
+
+homepage: "https://github.com/rocq-archive/sum-of-two-square"
+dev-repo: "git+https://github.com/rocq-archive/sum-of-two-square.git"
+bug-reports: "https://github.com/rocq-archive/sum-of-two-square/issues"
+license: "MIT"
+
+synopsis: "when a number n can be written as the sum of two square numbers"
+description: """
+
+This directory contains the proof that a number n can be written as the 
+sum of two square numbers if and only if each prime factor $p$ of $n$ 
+that is equal to 3 modulo 4 has its exponent in the decomposition of n
+that is even.
+
+A note on the development is available at [here](https://inria.hal.science/hal-05025371)
+
+
+To build the directory, type
+
+  make all
+
+Laurent Thery thery@sophia.inria.fr"""
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+depends: [
+  "coq" 
+]
+
+tags: [
+  "keyword:sum two square"
+  "logpath:SumOfTwoSquare"
+]
+authors: [
+  "Laurent Théry"
+]
+
+url {
+  src: "git+https://github.com/rocq-archive/sum-of-two-square.git#master"
+}

--- a/extra-dev/packages/coq-waterproof/coq-waterproof.dev/opam
+++ b/extra-dev/packages/coq-waterproof/coq-waterproof.dev/opam
@@ -26,7 +26,7 @@ bug-reports: "https://github.com/impermeable/coq-waterproof/issues"
 depends: [
   "ocaml" {>= "4.09.0"}
   "coq" {= "dev"}
-  "dune" {>= "3.8"}
+  "dune" {>= "3.8" & < "3.24"}
 ]
 
 build: [

--- a/extra-dev/packages/coq-waterproof/coq-waterproof.dev/opam
+++ b/extra-dev/packages/coq-waterproof/coq-waterproof.dev/opam
@@ -25,7 +25,7 @@ bug-reports: "https://github.com/impermeable/coq-waterproof/issues"
 
 depends: [
   "ocaml" {>= "4.09.0"}
-  "coq" {>= "9.0" & < "9.1" | = "dev"}
+  "coq" {= "dev"}
   "dune" {>= "3.8"}
 ]
 

--- a/extra-dev/packages/coq-waterproof/coq-waterproof.dev/opam
+++ b/extra-dev/packages/coq-waterproof/coq-waterproof.dev/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+name: "coq-waterproof"
+maintainer: "Jim Portegies <j.w.portegies@tue.nl>"
+authors: [
+  "Jelle Wemmenhove"
+  "Pim Otte"
+  "Balthazar Pathiachvili"
+  "Dick Arends"
+  "Cosmin Manea"
+  "Lulof Pirée"
+  "Adrian Vrămuleţ"
+  "Tudor Voicu"
+  "Jim Portegies <j.w.portegies@tue.nl>"
+]
+
+synopsis: "Coq proofs in a style that resembles non-mechanized mathematical proofs"
+description: """
+The Waterproof plugin for the Coq proof assistant allows you to write Coq proofs in a style that resembles handwritten mathematical proofs, designed to help university students with learning how to prove mathematical statements.
+"""
+
+license: "LGPL-3.0-or-later"
+homepage: "https://github.com/impermeable/coq-waterproof"
+dev-repo: "git+https://github.com/impermeable/coq-waterproof.git"
+bug-reports: "https://github.com/impermeable/coq-waterproof/issues"
+
+depends: [
+  "ocaml" {>= "4.09.0"}
+  "coq" {>= "9.0" & < "9.1" | = "dev"}
+  "dune" {>= "3.8"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs "@install"]
+]
+
+available: (arch != "s390x") & (arch != "ppc64")
+
+tags: [
+  "keyword:mathematics education"
+  "category:Mathematics/Education"
+  "date:2023-11-04"
+  "logpath:Waterproof"
+]
+
+url {
+  src: "git+https://github.com/impermeable/coq-waterproof.git#main"
+}

--- a/extra-dev/packages/coq-waterproof/coq-waterproof.dev/opam
+++ b/extra-dev/packages/coq-waterproof/coq-waterproof.dev/opam
@@ -43,5 +43,5 @@ tags: [
 ]
 
 url {
-  src: "git+https://github.com/impermeable/coq-waterproof.git#main"
+  src: "git+https://github.com/impermeable/coq-waterproof.git#coq-master"
 }


### PR DESCRIPTION
Adds 13 `extra-dev` recipes for packages whose newest archive release is capped below Rocq 9.0 but whose upstream metadata already claims Rocq 9.x, `dev`, or no upper bound. Companion to #3811, which covers packages whose upstream has not been ported.

| package | newest release | archive cap | upstream's own constraint | last upstream commit |
|---|---|---|---|---|
| coq-stalmarck | 8.20.0 | `< 8.21` | `coq {= "dev"}` | 2026-05-22 |
| coq-stalmarck-tactic | 8.20.0 | `< 8.21` | `coq {= "dev"}` | 2026-05-22 |
| coq-waterproof \* | 2.0.1+8.17 | `< 8.18` | `rocq-core {>= 9.1 & < 9.2 \| = dev}` | 2026-06-15 |
| coq-mathcomp-abel | 1.2.1 | `< 8.17~` | `rocq-core {>= "9.0"}` | 2026-07-21 |
| coq-hanoi | 1.0.0 | `< 8.16~` | `coq {>= "9.1"}` | 2026-01-29 |
| coq-cds4ltl | 1.0.0 | `< 8.17~` | `rocq-core {>= 9.1 & < 9.2~}` | 2026-05-04 |
| coq-mmaps | 1.1 | `< 8.21` | `coq {>= "8.16"}`, unbounded | 2026-06-22 |
| coq-mathcomp-apery | 1.0.2 | `< 8.19~` | `coq {>= "8.20"}`, unbounded | 2026-04-25 |
| coq-bits | 1.1.0 | `< 8.17~` | `coq {>= "8.16"}`, unbounded | 2026-03-03 |
| coq-coqtail | 8.20 | `< 8.21` | `coq {>= "8.17"}`, unbounded | 2026-04-13 |
| coq-comp-dec-modal | 1.2 | `< 8.21` | `coq {>= "8.16"}`, unbounded | 2024-08-11 |
| coq-sum-of-two-square | 8.10.0 | `< 8.11~` | `coq`, unbounded | 2026-01-30 |
| coq-exact-real-arithmetic | 8.10.0 | `< 8.11~` | (no opam file upstream) | 2026-02-05 |

\* `coq-waterproof` follows upstream's `coq-master` dev-tracking branch; every other row follows its repository's default branch.

## Recipes

Each recipe uses upstream's in-tree `.opam` file, drops `version:`, replaces the source with `url { src: "git+<repo>#<branch>" }`, and removes Coq/Rocq upper bounds because opam orders `dev` above every numeric version.

There are three other departures:

- `coq-waterproof` keeps only `coq {= "dev"}` of the three prover packages named upstream. `coq.dev` already brings `coq-core {= version}`, `rocq-runtime {= version}`, `coq-stdlib`, and `rocq-stdlib {= version}` at `dev`.
- `coq-sum-of-two-square` corrects `homepage`, `dev-repo`, and `bug-reports`, which point to a nonexistent `thery/SumOfTwoSquare` repository upstream.
- `coq-exact-real-arithmetic` has no upstream opam file, so its recipe starts from the newest release and swaps the tarball for git. It drops the obsolete `remove:` field and `light-uninstall` flag.

On waterproof's former `main` branch, this was necessary rather than cosmetic: `rocq-prover.9.3.dev` pins `rocq-core` to `9.3.dev`, which cannot coexist with the `rocq-runtime.dev` selected by `coq.dev`. The branch declares `version: "3.1.1+9.0-dev"`; `coq-master` declares `version: "3.1.1+dev"` and avoids `rocq-prover`. Tracking a dedicated prover branch is established practice: 71 of 304 `extra-dev/packages` `url { src: }` fragments use something other than `master` or `main`.

All rows now constrain the prover to `{= "dev"}`. The initial loose lower bounds let `opam-build:4.09.0`, which constrains `ocaml-base-compiler < 4.11.0`, resolve ported sources against old provers because `rocq-runtime` has required `ocaml >= 4.14.0` since 9.1+rc1. Pipeline 1455718, job 7695087 showed the result:

| resolved prover | rows | outcome |
|---|---|---|
| `coq.8.16.dev` | coq-comp-dec-modal, coq-mmaps | installed — **green, and meaningless** |
| `coq.8.20.dev` | coq-coqtail | installed — **green** |
| `coq.9.0.dev` (via `rocq-core.9.0.dev`) | coq-waterproof | installed — **green** |
| `coq.8.16.dev` | coq-bits, coq-exact-real-arithmetic, coq-sum-of-two-square | failed — **red, and equally meaningless** |
| — | the remaining 6 | `Package conflict!`, correctly skipped |

The failures were also old-prover artifacts. `coq-exact-real-arithmetic` and `coq-sum-of-two-square` use `From Stdlib Require`, producing `Cannot find a physical path bound to logical path ZArith with prefix Stdlib` on 8.x. `coq-bits` mixed `coq.8.16.dev` and `coq-mathcomp-algebra.2.2.0` with `coq-mathcomp-zify.dev`, then failed with `make: rocq: No such file or directory`.

The recipes therefore pin all 11 rows that did not already do so to the dev prover. They also pin the otherwise-unconstrained mathcomp dependencies of `coq-mathcomp-abel`, `coq-mathcomp-apery`, and `coq-bits` to `dev`. `coq-cds4ltl` (`rocq-core {>= "9.1"}`) and `coq-hanoi` (`coq {>= "9.1"}`) were already skipped on OCaml 4.09 because Rocq 9.1 requires OCaml 4.14; tightening those two is hygiene, while tightening the other nine fixes the bad resolutions.

## CI

Pipeline 1458297 tested PR head `0d8d6f9dc` merged with master. All three legs terminated. `opam-build:4.09.0` skips all 13 rows as not installable; zero are built, and its `succeeded`, `failed`, and `can never be installed` ledgers are empty. This is the intended resolution result, but it exercises none of the new recipes.

The 4.14.2 and 5.3.0 legs agreed: 13 attempted, 0 skipped, 8 installed, and 5 failed, with the same first error on both legs. Every installed row compiled files, ranging from 25 for `coq-cds4ltl` to 112 for `coq-mathcomp-apery`. The three pinned mathcomp rows had the same plans before and after tightening, so the change affects only 4.09.0.

| row | verdict | first error |
|---|---|---|
| coq-bits | installed | |
| coq-cds4ltl | installed | |
| coq-exact-real-arithmetic | installed | |
| coq-mathcomp-abel | installed | |
| coq-mathcomp-apery | installed | |
| coq-mmaps | installed | |
| coq-stalmarck | installed | |
| coq-sum-of-two-square | installed | |
| coq-stalmarck-tactic | failed | `dune-project:2 Error: Extension coq was deleted in the 3.24 version of the dune language` — `(using coq 0.3)` |
| coq-waterproof | failed | same error, `(using coq 0.8)` |
| coq-comp-dec-modal | failed | `edone.v:10 Unable to locate library mathcomp.ssreflect.ssreflect` |
| coq-coqtail | failed | `Complex/Canalysis_def.v:46 Error: The '%' scope delimiter in 'Arguments' commands is deprecated, use '%_' instead` |
| coq-hanoi | failed | `extra.v:225 Error: The LHS of subn_eq0 (_ - _ == 0) does not match any subterm of the goal` |

#3819 capped `dune < 3.24` for the 16 released elpi versions using the deleted extension and fixed the earlier `rocq-elpi.3.4.0` failure `Extension coq was deleted in the 3.24 version of the dune language`; both dev legs now resolve every elpi row to `dev`. The two remaining dune failures occur in `coq-stalmarck-tactic` and `coq-waterproof`, the only rows here that depend on dune. Their trees specify `(lang dune 2.8)` / `(using coq 0.3)` and `(lang dune 3.8)` / `(using coq 0.8)`, respectively, so their recipes add the same ceiling used by #3819:

```
-  "dune" {>= "2.8"}
+  "dune" {>= "2.8" & < "3.24"}
```

The waterproof constraint is likewise `{>= "3.8" & < "3.24"}`. This remains compatible with `rocq-runtime.dev` and `rocq-core.dev`, which require `dune {>= "3.21"}`. Both files pass `opam lint --warn=-21`. The ceiling is a stopgap until the projects move to `(using rocq …)`.

`coq-waterproof` also moves from `#main`, upstream's released line, to its development-prover branch:

```
-  src: "git+https://github.com/impermeable/coq-waterproof.git#main"
+  src: "git+https://github.com/impermeable/coq-waterproof.git#coq-master"
```

`coq-master` contains the adaptations for `rocq-prover/rocq#21987` and `rocq-prover/rocq#22114`; `main` trails it by 90 commits across 117 files, including 12 under `src/`. The 10 commits present only on `main` are a `3.1.1+...-dev` version bump, two coq-lsp documentation updates, and a notation tweak.

### Dune cap and waterproof branch results

The dune-cap-only commit 072925e2d ran in pipeline 1459862. `opam-build:4.14.2` (job 7723631) and `opam-build:5.3.0` (job 7723632) produced byte-identical ledgers: `coq-stalmarck-tactic.dev` installed, while `coq-waterproof.dev` failed. The capped packages' own solves selected:

```
- install dune 3.23.1 [required by coq-stalmarck-tactic]
- install dune 3.23.1 [required by coq-waterproof]
```

Those attributions occur at log lines 3644 and 4187 on 4.14.2 and 3736 and 4321 on 5.3.0. Across all ten independent solves, dune was otherwise only constrained to `>= 3.21` and resolved to 3.24.2 five times and 3.23.1 five times, including three uncapped rows; the attribution, not the selected version alone, shows the cap acted.

Before the cap, pipeline 1458297's 4.14.2 leg (job 7713621) selected `- install dune 3.24.2 [required by coq-waterproof]` at log line 4671 and `[required by coq-stalmarck-tactic]` at 4146; both then failed at `dune-project:2` with `Error: Extension coq was deleted in the 3.24 version of the dune language` at lines 4704 and 4180. The 5.3.0 leg agrees at lines 4631 and 4125. This establishes that the cap affects each row's independent solve.

After the cap, waterproof passed `dune-project` but exposed six OCaml API errors under `src/`, identically on both OCaml versions. The first was:

```
File "src/unfold_framework.mli", line 54, characters 56-84:
54 | val register_unfold : string list -> Libnames.qualid -> notation_interpretation_data * notation_interpretation_data
                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: The type constructor "notation_interpretation_data"
       expects 2 argument(s), but is here applied to 0 argument(s)
```

The other sites were `exceptions.ml:176`, `proofutils.ml:208`, `wp_rewrite.ml:36`, `wp_auto.ml:129`, and `wp_eauto.ml`. All are adapted on `coq-master`.

The repointing commit a01f994c7 ran in pipeline 1459864. Both `opam-build:4.14.2` (job 7723639) and `opam-build:5.3.0` (job 7723640) attempted 10 rows and installed all 10, with empty failure ledgers at log lines 4741 and 4883. The control and treatment trees differed only in waterproof's `url { src: }`: control 7f0ebc50 used `#main`, while treatment bf5f4c33 used `#coq-master`.

Both changes are required. `coq-master` tip f49b8305b still uses `(lang dune 3.8)` / `(using coq 0.8)`, so without the cap it fails at `dune-project:2`; without the branch change, the capped row fails at `unfold_framework.mli:54`. `coq-stalmarck-tactic`'s recipe is byte-identical (877 B) between control and treatment, so its four green cells represent two results. It is the 7th row and waterproof the 10th; all four legs ran through their final ledgers. The control legs took 7,411 s and 8,225 s, and the treatment legs 11,746 s and 12,544 s, under the 86,400 s GitLab limit.

### Known source failures

ci-skip: coq-comp-dec-modal coq-coqtail coq-hanoi

These three default branches have not been ported to Rocq dev, and no archive constraint fixes their source failures. `.gitlab-ci.yml` reads `ci-skip:` from this PR body only, so the skip does not apply when another PR touches the rows. The recipes knowingly remain red; they can instead be dropped if the archive should not carry them in that state.

- `coq-comp-dec-modal` also fails against Rocq 9.2 with mathcomp 2.5.0+9.2 at `bcase.v:5` and `edone.v:10`; it builds only with mathcomp 2.4.0. `ssreflect.v` moved out of `ssreflect/` in mathcomp 2.5.0. Its `coq-mathcomp-ssreflect {>= "2.0"}` floor is therefore loose.
- `coq-coqtail` still uses the bare `%` delimiter in `Arguments`. The opam log elides the file/line and `Error:` head, but retains the suggested `for f in $(find . -name '*.v'); do sed '/Arguments/ s/%/%_/g' -i $f; done`, the `[argument-scope-delimiter,deprecated-since-8.19,…]` tag, and `Complex/Canalysis_def.vo` as the failed target.
- `coq-hanoi` has a proof break against mathcomp dev: `subn_eq0` no longer matches at `extra.v:225`.

None of these three has a dependent under `released/`, `extra-dev/`, or `core-dev/`; searching the archive found zero occurrences outside their own directories, versus 568 for the `coq-mathcomp-ssreflect` control.

## Not included and caveats

`coq-library-fol` has a ported `rocq-9.0` branch and tag `v1.1+9.0.1`, but its opam file pins exact versions of `coq-library-undecidability` and `rocq-metarocq-template` absent from this archive and supplies them through `pin-depends:`. It needs a released `1.1+9.0.1` recipe instead.

The recipes were not build-verified when first opened; their first actual builds were this CI. All 13 pass `opam lint --warn=-21 --check-upstream`. `coq-exact-real-arithmetic` retains a non-SPDX license warning and `coq-sum-of-two-square` an uncapitalized synopsis warning. Every named dependency already has a `.dev` or `core-dev` recipe in the archive.

The packages were selected by surveying the 175 archive packages whose newest release is capped below Rocq 9.0 or which declare no coq/rocq dependency, then comparing upstream activity and in-tree opam constraints.

Wordsmithed by Codex.
