### PR TITLE
extra-dev: dev recipes for 9 packages that stopped at Coq 8.19-8.21

### DIFF
--- a/extra-dev/packages/coq-almost-full/coq-almost-full.dev/opam
+++ b/extra-dev/packages/coq-almost-full/coq-almost-full.dev/opam
@@ -1,0 +1,39 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/almost-full"
+dev-repo: "git+https://github.com/coq-community/almost-full.git"
+bug-reports: "https://github.com/coq-community/almost-full/issues"
+license: "MIT"
+
+synopsis: "Almost-full relations in Coq for proving termination"
+description: """
+Coq development of almost-full relations, including the Ramsey
+Theorem, useful for proving termination."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "dune" {>= "3.5"}
+  "coq" {>= "8.11"}
+]
+
+tags: [
+  "category:Computer Science/Data Types and Data Structures"
+  "keyword:Ramsey theorem"
+  "keyword:termination"
+  "keyword:almost-full relations"
+  "keyword:well-founded relations"
+  "logpath:AlmostFull"
+]
+authors: [
+  "Dimitrios Vytiniotis"
+  "Thierry Coquand"
+  "David Wahlstedt"
+]
+
+url {
+  src: "git+https://github.com/rocq-community/almost-full.git#master"
+}

--- a/extra-dev/packages/coq-almost-full/coq-almost-full.dev/opam
+++ b/extra-dev/packages/coq-almost-full/coq-almost-full.dev/opam
@@ -17,7 +17,7 @@ Theorem, useful for proving termination."""
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "3.5"}
-  "coq" {>= "8.11"}
+  "coq" {= "dev"}
 ]
 
 tags: [

--- a/extra-dev/packages/coq-belgames/coq-belgames.dev/opam
+++ b/extra-dev/packages/coq-belgames/coq-belgames.dev/opam
@@ -1,0 +1,43 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "erik.martin-dorel@irit.fr"
+
+homepage: "https://github.com/pPomCo/belgames"
+dev-repo: "git+https://github.com/pPomCo/belgames.git"
+bug-reports: "https://github.com/pPomCo/belgames/issues"
+license: "MIT"
+
+synopsis: "BelGames: A Formal Theory of Games of Incomplete Information Based on Belief Functions in the Coq Proof Assistant"
+description: """
+We extend Bayesian games to the theory of belief functions. We
+obtain a more expressive class of games we refer to as BelGames. It
+makes it possible to better capture human behaviors with respect to
+lack of information.
+Next, we prove an extended version of the so-called
+Howson--Rosenthal's theorem, showing that BelGames can be turned
+into games of complete information, i.e., without any uncertainty."""
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+depends: [
+  "coq" {(>= "8.16")}
+  "coq-mathcomp-algebra" {>= "2.0"}
+]
+
+tags: [
+  "keyword:games of incomplete information"
+  "keyword:belief functions theory"
+  "keyword:mathcomp/ssreflect"
+  "logpath:BelGames"
+]
+authors: [
+  "Pierre Pomeret-Coquot"
+  "Erik Martin-Dorel"
+  "Hélène Fargier"
+]
+
+url {
+  src: "git+https://github.com/pPomCo/belgames.git#main"
+}

--- a/extra-dev/packages/coq-belgames/coq-belgames.dev/opam
+++ b/extra-dev/packages/coq-belgames/coq-belgames.dev/opam
@@ -22,8 +22,8 @@ into games of complete information, i.e., without any uncertainty."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.16")}
-  "coq-mathcomp-algebra" {>= "2.0"}
+  "coq" {= "dev"}
+  "coq-mathcomp-algebra" {= "dev"}
 ]
 
 tags: [

--- a/extra-dev/packages/coq-high-school-geometry/coq-high-school-geometry.dev/opam
+++ b/extra-dev/packages/coq-high-school-geometry/coq-high-school-geometry.dev/opam
@@ -18,7 +18,7 @@ Includes a proof of Ptolemy's theorem."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.18"}
+  "coq" {= "dev"}
 ]
 
 tags: [

--- a/extra-dev/packages/coq-high-school-geometry/coq-high-school-geometry.dev/opam
+++ b/extra-dev/packages/coq-high-school-geometry/coq-high-school-geometry.dev/opam
@@ -1,0 +1,39 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/HighSchoolGeometry"
+dev-repo: "git+https://github.com/coq-community/HighSchoolGeometry.git"
+bug-reports: "https://github.com/coq-community/HighSchoolGeometry/issues"
+license: "LGPL-2.1-or-later"
+
+synopsis: "Geometry in Coq for French high school"
+description: """
+This Coq library is dedicated to high-shool geometry teaching. The
+axiomatisation for affine Euclidean space is in a non analytic setting.
+Includes a proof of Ptolemy's theorem."""
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+depends: [
+  "coq" {>= "8.18"}
+]
+
+tags: [
+  "category:Mathematics/Geometry/General"
+  "keyword:geometry"
+  "keyword:teaching"
+  "keyword:high school"
+  "keyword:Ptolemy's theorem"
+  "logpath:HighSchoolGeometry"
+]
+authors: [
+  "Frédérique Guilhot"
+  "Tuan-Minh Pham"
+]
+
+url {
+  src: "git+https://github.com/rocq-community/HighSchoolGeometry.git#master"
+}

--- a/extra-dev/packages/coq-jmlcoq/coq-jmlcoq.dev/opam
+++ b/extra-dev/packages/coq-jmlcoq/coq-jmlcoq.dev/opam
@@ -18,7 +18,7 @@ verified runtime assertion checker for JML."""
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "3.5"}
-  "coq" {>= "8.10"}
+  "coq" {= "dev"}
 ]
 
 tags: [

--- a/extra-dev/packages/coq-jmlcoq/coq-jmlcoq.dev/opam
+++ b/extra-dev/packages/coq-jmlcoq/coq-jmlcoq.dev/opam
@@ -1,0 +1,39 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/jmlcoq"
+dev-repo: "git+https://github.com/coq-community/jmlcoq.git"
+bug-reports: "https://github.com/coq-community/jmlcoq/issues"
+license: "MIT"
+
+synopsis: "Coq definition of the JML specification language and a verified runtime assertion checker for JML"
+description: """
+A Coq formalization of the syntax and semantics of the
+Java-targeted JML specification language, along with a
+verified runtime assertion checker for JML."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "dune" {>= "3.5"}
+  "coq" {>= "8.10"}
+]
+
+tags: [
+  "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms"
+  "keyword:JML"
+  "keyword:Java Modeling Language"
+  "keyword:runtime verification"
+  "logpath:JML"
+]
+authors: [
+  "Hermann Lehner"
+  "David Pichardie"
+  "Andreas Kägi"
+]
+
+url {
+  src: "git+https://github.com/rocq-community/jmlcoq.git#master"
+}

--- a/extra-dev/packages/coq-mk-reals-axioms/coq-mk-reals-axioms.dev/opam
+++ b/extra-dev/packages/coq-mk-reals-axioms/coq-mk-reals-axioms.dev/opam
@@ -21,7 +21,7 @@ authors: [
 license: "LGPL-2.1-only"
 
 depends: [
-  "coq" {>= "8.13.2"}
+  "coq" {= "dev"}
 ]
 
 build: [

--- a/extra-dev/packages/coq-mk-reals-axioms/coq-mk-reals-axioms.dev/opam
+++ b/extra-dev/packages/coq-mk-reals-axioms/coq-mk-reals-axioms.dev/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "A Coq formalization of the axiomatic definition of real numbers"
+description: """
+This repository presents a Coq formalization of the axiomatic definition of real numbers,
+guided by the 2nd chapter of Zorich's Mathematical Analysis (Part I, 7th expanded edition) and
+based on the formalization of Morse-Kelley (MK) set theory.
+In this work, the key algebraic properties and the uniqueness of real number structure are verified.
+"""
+
+homepage: "https://github.com/1DGW/coq-mk-reals-axioms"
+dev-repo: "git+https://github.com/1DGW/coq-mk-reals-axioms.git"
+bug-reports: "https://github.com/1DGW/coq-mk-reals-axioms/issues"
+maintainer: "dgw@bupt.edu.cn"
+authors: [
+  "Wensheng Yu"
+  "Dakai Guo"
+  "Si Chen"
+  "Guowei Dou"
+  "Shukun Len"
+]
+license: "LGPL-2.1-only"
+
+depends: [
+  "coq" {>= "8.13.2"}
+]
+
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+
+tags: [
+  "keyword:set theory"
+  "keyword:Morse-Kelley"
+  "keyword:MK"
+  "real numbers"
+  "category:Mathematics/Logic/Set theory"
+  "date:2024-08-22"
+  "logpath:MKReals"
+]
+
+url {
+  src: "git+https://github.com/1DGW/coq-mk-reals-axioms.git#main"
+}

--- a/extra-dev/packages/coq-morse-kelley-axiomatic-set-theory/coq-morse-kelley-axiomatic-set-theory.dev/opam
+++ b/extra-dev/packages/coq-morse-kelley-axiomatic-set-theory/coq-morse-kelley-axiomatic-set-theory.dev/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "A Coq formalization of the Morse-Kelley axiomatic set theory"
+description: """
+In this project, we present a formalization of axiomatic set theory based on the Coq proof assistant.
+The axiomatic system is derived from Morse-Kelley (MK) set theory which is a relatively complete and concise axiomatic set theory.
+
+MK includes eight axioms, one axiom schema, and 181 definitions or theorems. 
+Different from ZFC, MK admits classes (whose quantity is more extensive than that of sets) as fundamental objects. 
+That is to say, every mathematical object (ordered pair, function, integer, etc.) is a class, 
+and only those classes belonging to some other ones are defined as sets. 
+The non-set classes are named “proper classes”. In fact, ZFC can be proven consistent in MK. 
+We consider that MK is a proper extension of ZFC and is convenient to utilize in formalization processes.
+"""
+
+homepage: "https://github.com/1DGW/formalization-of-Morse-Kelley-axiomatic-set-theory"
+dev-repo: "git+https://github.com/1DGW/formalization-of-Morse-Kelley-axiomatic-set-theory.git"
+bug-reports: "https://github.com/1DGW/formalization-of-Morse-Kelley-axiomatic-set-theory/issues"
+maintainer: "dgw@bupt.edu.cn"
+authors: [
+  "Wensheng Yu"
+  "Tianyu Sun"
+  "Yaoshun Fu"
+  "Dakai Guo"
+  "Si Chen"
+  "Qimeng Zhang"
+  "Guowei Dou"
+]
+license: "LGPL-2.1"
+
+depends: [
+  "coq" {>= "8.13.2"}
+]
+
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+
+tags: [
+  "keyword:set theory"
+  "keyword:axiomatic set theory"
+  "keyword:Morse-Kelley"
+  "keyword:MK"
+  "category:Mathematics/Logic/Set theory"
+  "date:2024-07-24"
+  "logpath:MorseKelley"
+]
+
+url {
+  src: "git+https://github.com/1DGW/formalization-of-Morse-Kelley-axiomatic-set-theory.git#main"
+}

--- a/extra-dev/packages/coq-morse-kelley-axiomatic-set-theory/coq-morse-kelley-axiomatic-set-theory.dev/opam
+++ b/extra-dev/packages/coq-morse-kelley-axiomatic-set-theory/coq-morse-kelley-axiomatic-set-theory.dev/opam
@@ -28,7 +28,7 @@ authors: [
 license: "LGPL-2.1"
 
 depends: [
-  "coq" {>= "8.13.2"}
+  "coq" {= "dev"}
 ]
 
 build: [

--- a/extra-dev/packages/coq-qarith-stern-brocot/coq-qarith-stern-brocot.dev/opam
+++ b/extra-dev/packages/coq-qarith-stern-brocot/coq-qarith-stern-brocot.dev/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/qarith-stern-brocot"
+dev-repo: "git+https://github.com/coq-community/qarith-stern-brocot.git"
+bug-reports: "https://github.com/coq-community/qarith-stern-brocot/issues"
+license: "LGPL-2.1-or-later"
+
+synopsis: "Binary rational numbers in Coq"
+description: """
+Development of rational numbers in Coq as finite binary lists and defining
+field operations on them in two different ways: strict and lazy.
+"""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "dune" {>= "3.5"}
+  "coq" {>= "8.18"}
+]
+
+tags: [
+  "category:Mathematics/Arithmetic and Number Theory/Rational numbers"
+  "category:Miscellaneous/Extracted Programs/Arithmetic"
+  "keyword:rational numbers"
+  "keyword:arithmetic"
+  "keyword:field tactic"
+  "keyword:binary lists"
+  "keyword:Stern-Brocot"
+  "logpath:QArithSternBrocot"
+]
+authors: [
+  "Milad Niqui"
+  "Yves Bertot"
+]
+
+url {
+  src: "git+https://github.com/rocq-community/qarith-stern-brocot.git#master"
+}

--- a/extra-dev/packages/coq-qarith-stern-brocot/coq-qarith-stern-brocot.dev/opam
+++ b/extra-dev/packages/coq-qarith-stern-brocot/coq-qarith-stern-brocot.dev/opam
@@ -15,7 +15,7 @@ field operations on them in two different ways: strict and lazy.
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "3.5"}
-  "coq" {>= "8.18"}
+  "coq" {= "dev"}
 ]
 
 tags: [

--- a/extra-dev/packages/coq-quantumlib/coq-quantumlib.dev/opam
+++ b/extra-dev/packages/coq-quantumlib/coq-quantumlib.dev/opam
@@ -12,7 +12,7 @@ doc: "https://inqwire.github.io/QuantumLib/toc.html"
 bug-reports: "https://github.com/inQWIRE/QuantumLib/issues"
 depends: [
   "dune" {>= "2.8"}
-  "coq" {>= "8.16"}
+  "coq" {= "dev"}
   "odoc" {with-doc}
 ]
 build: [

--- a/extra-dev/packages/coq-quantumlib/coq-quantumlib.dev/opam
+++ b/extra-dev/packages/coq-quantumlib/coq-quantumlib.dev/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Coq library for reasoning about quantum programs"
+description: """
+inQWIRE's QuantumLib is a Coq library for reasoning
+ about quantum computation and quantum programs.
+"""
+maintainer: ["inQWIRE Developers"]
+authors: ["inQWIRE"]
+license: "MIT"
+homepage: "https://github.com/inQWIRE/QuantumLib"
+doc: "https://inqwire.github.io/QuantumLib/toc.html"
+bug-reports: "https://github.com/inQWIRE/QuantumLib/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "coq" {>= "8.16"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/inQWIRE/QuantumLib.git"
+
+url {
+  src: "git+https://github.com/inQWIRE/QuantumLib.git#main"
+}

--- a/extra-dev/packages/coq-sudoku/coq-sudoku.dev/opam
+++ b/extra-dev/packages/coq-sudoku/coq-sudoku.dev/opam
@@ -17,7 +17,7 @@ Davis-Putnam procedure to solve Sudokus."""
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
-  "coq" {(>= "8.12" & < "8.15~") | (= "dev")}
+  "coq" {= "dev"}
 ]
 
 tags: [

--- a/extra-dev/packages/coq-sudoku/coq-sudoku.dev/opam
+++ b/extra-dev/packages/coq-sudoku/coq-sudoku.dev/opam
@@ -1,0 +1,36 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/sudoku"
+dev-repo: "git+https://github.com/coq-community/sudoku.git"
+bug-reports: "https://github.com/coq-community/sudoku/issues"
+license: "LGPL-2.1-or-later"
+
+synopsis: "Sudoku solver certified in Coq"
+description: """
+A formalisation of Sudoku in Coq. It implements a naive
+Davis-Putnam procedure to solve Sudokus."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "dune" {>= "2.5"}
+  "coq" {(>= "8.12" & < "8.15~") | (= "dev")}
+]
+
+tags: [
+  "category:Miscellaneous/Logical Puzzles and Entertainment"
+  "keyword:puzzles"
+  "keyword:Davis-Putnam"
+  "keyword:sudoku"
+  "logpath:Sudoku"
+]
+authors: [
+  "Laurent Théry"
+]
+
+url {
+  src: "git+https://github.com/rocq-community/sudoku.git#master"
+}


### PR DESCRIPTION
Adds 9 `extra-dev` recipes for packages whose newest release is capped below Rocq 9.0 and whose upstream has no evidence of a port. Unlike #3810, these recipes intentionally expose concrete upstream porting work and are expected to include failures.

| package | newest release | archive cap | upstream's own constraint | last upstream commit |
|---|---|---|---|---|
| coq-quantumlib | 1.8.0 | `< 8.21` | `coq {>= 8.16 & < 8.21}` | 2025-09-19 |
| coq-belgames | 2.0.0 | `< 8.19~` | `coq {>= 8.16 & < 8.19~}` | 2023-11-06 |
| coq-sudoku | 8.16.0 | `< 8.20` | `coq {8.12–8.15~ \| = dev}` | 2022-10-19 |
| coq-almost-full | 8.18.0 | `< 8.20` | `coq {>= "8.11"}`, unbounded | 2023-12-30 |
| coq-qarith-stern-brocot | 8.18.0 | `< 8.21~` | `coq {>= "8.18"}`, unbounded | 2023-12-30 |
| coq-jmlcoq | 8.15.0 | `< 8.20` | `coq {>= "8.10"}`, unbounded | 2023-12-30 |
| coq-high-school-geometry | 8.16.0 | `< 8.21` | `coq {>= "8.18"}`, unbounded | 2024-07-13 |
| coq-mk-reals-axioms | 1.0.0 | `< 8.21~` | (no opam file upstream) | 2024-08-22 |
| coq-morse-kelley-axiomatic-set-theory | 1.0.0 | `< 8.21~` | (no opam file upstream) | 2024-07-24 |

## Recipes and constraints

Each recipe uses upstream's in-tree `.opam` at the default branch, drops `version:`, replaces the source with `url { src: "git+<repo>#<branch>" }`, and drops Coq/Rocq upper bounds because opam orders `dev` above every numeric version. `coq-mk-reals-axioms` and `coq-morse-kelley-axiomatic-set-theory` have no upstream opam file, so their released recipes are used with the tarball replaced by the git source.

All nine rows now constrain `coq {= "dev"}`. Pipeline 1455719, job 7695092 showed why: `opam-build:4.09.0` constrains `ocaml-base-compiler < 4.11.0`, while `rocq-runtime` has required `ocaml >= 4.14.0` since 9.1+rc1. Loose lower bounds therefore resolved all nine recipes against released provers rather than skipping them:

| resolved prover | rows |
|---|---|
| `coq.8.16.dev` | coq-almost-full, coq-belgames, coq-jmlcoq, coq-mk-reals-axioms, coq-morse-kelley-axiomatic-set-theory, coq-quantumlib |
| `coq.8.20.dev` | coq-high-school-geometry, coq-qarith-stern-brocot |
| `coq.8.14.dev` | coq-sudoku |

`coq-sudoku`'s alternative `| (= "dev")` did not prevent resolution to `coq.8.14.dev`; only `{= "dev"}` on its own does. `coq-belgames`' otherwise-unconstrained `coq-mathcomp-algebra` is also pinned to `dev`. These changes affect the 4.09.0 leg, while the dev legs already resolved `dev` for every row.

## CI evidence

Pipeline 1455719 (sha `516e1984ab`), before constraint tightening, produced identical results on the 4.14.2 and 5.3.0 dev legs:

| row | 4.14.2 / 5.3.0 | files installed | note |
|---|---|---|---|
| coq-high-school-geometry | **installed** | 205 | needs no port |
| coq-morse-kelley-axiomatic-set-theory | **installed** | 7 | needs no port |
| coq-belgames | *installed* | **0** | hollow green; see below |
| coq-almost-full | failed | 0 | |
| coq-jmlcoq | failed | 0 | |
| coq-mk-reals-axioms | failed | 0 | |
| coq-qarith-stern-brocot | failed | 0 | |
| coq-quantumlib | failed | 0 | |
| coq-sudoku | failed | 0 | |

The two successful packages build unchanged. Morse-kelley's 7 files are its complete development (`mk_structure` and `mk_theorems`, `.v`/`.vo`/`.glob`).

`coq-belgames` compiled nothing despite reporting success. Upstream commits a generated `Makefile.coq.conf` from Coq 8.17 containing:

```make
COQMF_SOURCES := $(shell $(COQMKFILE) -sources-of -f _CoqProject $(COQMF_CMDLINE_VFILES))
```

At Rocq dev, `-sources-of` requires a suffix argument (`rocqmakefile.ml`, changed in `926aa6ecbf`, first released in 9.3+rc1). It consumes `-f` as the suffix, yields an empty file list, and leaves `real-all: $(VOFILES)` with nothing to do. The makefile is not regenerated because `Makefile.coq: _CoqProject` sees equal mtimes in a fresh clone.

On pristine upstream `main` (`31df26f`), the committed files produce rc=0, **0** `.vo`, and `Nothing to be done for 'real-all'`. Removing the two generated files produces rc=2, 1 of 17 `.vo`, and three errors representing three break classes. Thus belgames needs a port despite its green result. Repositories tracking `Makefile.coq` or `Makefile.coq.conf` and using plain `make` can exhibit the same false green at 9.3 or later.

The six red rows, plus belgames in substance, fail because their sources have not been ported; archive metadata cannot fix them.

## Exclusions and caveats

`coq-katamaran` is excluded despite `(coq (and (>= 8.20) (< 9.1)))`: the archive has no `coq-iris.dev` or `coq-stdpp.dev`, so its recipe could not resolve, and its `(using coq 0.4)` declaration is unsupported by dune 3.24. `coq-plouffe` has no usable `dev-repo:`.

The recipes were not build-verified when first opened. All 9 pass `opam lint --warn=-21 --check-upstream`; `coq-morse-kelley-axiomatic-set-theory` retains one non-SPDX license warning from its source. Every named dependency already has a `.dev` recipe in this archive.

The set came from 175 archive packages whose newest release is capped below Rocq 9.0 or lacks a coq/rocq dependency. Nine of nine rows initially resolved on 4.09.0; #3810's corresponding result was seven of thirteen.

Wordsmithed by Codex.
