### PR TITLE
rocq-parseque.0.3.1 is compatible with Rocq 9.3

### DIFF
--- a/released/packages/rocq-parseque/rocq-parseque.0.3.1/opam
+++ b/released/packages/rocq-parseque/rocq-parseque.0.3.1/opam
@@ -14,7 +14,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "rocq-core" {>= "9.0" & < "9.3~"}
+  "rocq-core" {>= "9.0" & < "9.4~"}
   "rocq-stdlib"
 ]
 


### PR DESCRIPTION
The package is already in nixpkgs with Rocq 9.3, and compiles with the docker image rocq/rocq-prover:dev [see here](https://github.com/rocq-community/parseque/actions/runs/31468500186/job/93706407701).