### PR TITLE
extra-dev: use { != version } for the coq-* wrapper exclusion on 8 rocq-*.dev rows

### DIFF
--- a/extra-dev/packages/rocq-hierarchy-builder/rocq-hierarchy-builder.dev/opam
+++ b/extra-dev/packages/rocq-hierarchy-builder/rocq-hierarchy-builder.dev/opam
@@ -15,7 +15,7 @@ depends: [
   "rocq-elpi" {>= "2.4" | = "dev"}
 ]
 conflicts: [
-  "coq-hierarchy-builder" {< "1.9~"}
+  "coq-hierarchy-builder" { != version }
   "coq-hierarchy-builder-shim"
 ]
 depexts: [

--- a/extra-dev/packages/rocq-mathcomp-analysis-stdlib/rocq-mathcomp-analysis-stdlib.dev/opam
+++ b/extra-dev/packages/rocq-mathcomp-analysis-stdlib/rocq-mathcomp-analysis-stdlib.dev/opam
@@ -18,7 +18,7 @@ depends: [
   "rocq-mathcomp-reals-stdlib"
 ]
 
-conflicts: [ "coq-mathcomp-analysis-stdlib" { < "1.16~" } ]
+conflicts: [ "coq-mathcomp-analysis-stdlib" { != version } ]
 
 tags: [
   "category:Mathematics/Real Numbers"

--- a/extra-dev/packages/rocq-mathcomp-analysis/rocq-mathcomp-analysis.dev/opam
+++ b/extra-dev/packages/rocq-mathcomp-analysis/rocq-mathcomp-analysis.dev/opam
@@ -21,7 +21,7 @@ depends: [
   "rocq-navi" {= "0.5.1" & with-doc}
 ]
 
-conflicts: [ "coq-mathcomp-analysis" { < "1.16~" } ]
+conflicts: [ "coq-mathcomp-analysis" { != version } ]
 
 tags: [
   "category:Mathematics/Real Calculus and Topology"

--- a/extra-dev/packages/rocq-mathcomp-classical/rocq-mathcomp-classical.dev/opam
+++ b/extra-dev/packages/rocq-mathcomp-classical/rocq-mathcomp-classical.dev/opam
@@ -20,7 +20,7 @@ depends: [
   "rocq-hierarchy-builder" { (>= "1.8.0") }
 ]
 
-conflicts: [ "coq-mathcomp-classical" { < "1.16~" } ]
+conflicts: [ "coq-mathcomp-classical" { != version } ]
 
 tags: [
   "category:Mathematics/Logic/Classical logic"

--- a/extra-dev/packages/rocq-mathcomp-experimental-reals/rocq-mathcomp-experimental-reals.dev/opam
+++ b/extra-dev/packages/rocq-mathcomp-experimental-reals/rocq-mathcomp-experimental-reals.dev/opam
@@ -21,7 +21,7 @@ depends: [
   "rocq-mathcomp-bigenough" { (>= "1.0.0") }
 ]
 
-conflicts: [ "coq-mathcomp-experimental-reals" { < "1.16~" } ]
+conflicts: [ "coq-mathcomp-experimental-reals" { != version } ]
 
 tags: [
   "category:Mathematics/Real Numbers"

--- a/extra-dev/packages/rocq-mathcomp-multinomials/rocq-mathcomp-multinomials.dev/opam
+++ b/extra-dev/packages/rocq-mathcomp-multinomials/rocq-mathcomp-multinomials.dev/opam
@@ -24,7 +24,7 @@ depends: [
   "coq-mathcomp-bigenough" 
   "coq-mathcomp-finmap" 
 ]
-conflicts: [ "coq-mathcomp-multinomials" {<= "2.4.0"} ]
+conflicts: [ "coq-mathcomp-multinomials" { != version } ]
 
 tags: [
   "category:Mathematics/Algebra/Multinomials"

--- a/extra-dev/packages/rocq-mathcomp-reals-stdlib/rocq-mathcomp-reals-stdlib.dev/opam
+++ b/extra-dev/packages/rocq-mathcomp-reals-stdlib/rocq-mathcomp-reals-stdlib.dev/opam
@@ -19,7 +19,7 @@ depends: [
   "rocq-mathcomp-reals" { = version}
 ]
 
-conflicts: [ "coq-mathcomp-reals-stdlib" { < "1.16~" } ]
+conflicts: [ "coq-mathcomp-reals-stdlib" { != version } ]
 
 tags: [
   "category:Mathematics/Real Numbers"

--- a/extra-dev/packages/rocq-mathcomp-reals/rocq-mathcomp-reals.dev/opam
+++ b/extra-dev/packages/rocq-mathcomp-reals/rocq-mathcomp-reals.dev/opam
@@ -17,7 +17,7 @@ depends: [
   "rocq-mathcomp-classical" { = version}
 ]
 
-conflicts: [ "coq-mathcomp-reals" { < "1.16~" } ]
+conflicts: [ "coq-mathcomp-reals" { != version } ]
 
 tags: [
   "category:Mathematics/Real Numbers"


### PR DESCRIPTION
Eight `rocq-*.dev` rows exclude their `coq-*` compatibility wrapper with a fixed bound. Replace those bounds with `{ != version }`:

| row | was | now |
| --- | --- | --- |
| `rocq-hierarchy-builder.dev` | `coq-hierarchy-builder {< "1.9~"}` | `{ != version }` |
| `rocq-mathcomp-analysis.dev` | `coq-mathcomp-analysis {< "1.16~"}` | `{ != version }` |
| `rocq-mathcomp-analysis-stdlib.dev` | `coq-mathcomp-analysis-stdlib {< "1.16~"}` | `{ != version }` |
| `rocq-mathcomp-classical.dev` | `coq-mathcomp-classical {< "1.16~"}` | `{ != version }` |
| `rocq-mathcomp-experimental-reals.dev` | `coq-mathcomp-experimental-reals {< "1.16~"}` | `{ != version }` |
| `rocq-mathcomp-multinomials.dev` | `coq-mathcomp-multinomials {<= "2.4.0"}` | `{ != version }` |
| `rocq-mathcomp-reals.dev` | `coq-mathcomp-reals {< "1.16~"}` | `{ != version }` |
| `rocq-mathcomp-reals-stdlib.dev` | `coq-mathcomp-reals-stdlib {< "1.16~"}` | `{ != version }` |

A wrapper uses `depends: [ "rocq-Y" {= version} ]`; `{ != version }` is its exact complement. Fixed bounds work only while they coincide with the wrapper boundary.

This is currently a no-op. The highest file-installing versions are `coq-hierarchy-builder` 1.8.1, the six `coq-mathcomp-*` packages at 1.9.0, and `coq-mathcomp-multinomials` 2.4.0. Later versions—1.9.0, 1.9.1, 1.10.0–1.10.3 and dev; 1.16.0 and dev; or 2.5.0 and dev—are wrappers whose `rocq-Y = V` tie already excludes `rocq-Y.dev`. `{ != version }` also excludes future file-installing releases above the old bounds.

The remaining `rocq-hierarchy-builder.dev` conflict, `coq-hierarchy-builder-shim`, is unchanged.

`opam lint --short` reports no failures or notes on all 8 files. The diff is 8 insertions and 8 deletions. A companion PR covers the 27 `rocq-*.dev` rows without an exclusion; either can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Wordsmithed by Codex.
