### PR TITLE
Add upper bounds to coq-coquelicot

### DIFF
--- a/released/packages/coq-coquelicot/coq-coquelicot.2.1.1/opam
+++ b/released/packages/coq-coquelicot/coq-coquelicot.2.1.1/opam
@@ -11,7 +11,7 @@ build: [
 install: ["./remake" "install"]
 depends: [
   "coq" {>= "8.4pl4" & < "8.6~"}
-  "coq-mathcomp-ssreflect" {>= "1.6"}
+  "coq-mathcomp-ssreflect" {>= "1.6" & < "1.16~"}
 ]
 tags: [ "keyword:real analysis" "keyword:topology" "keyword:filters" "keyword:metric spaces" "category:Mathematics/Real Calculus and Topology" ]
 authors: [ "Sylvie Boldo <sylvie.boldo@inria.fr>" "Catherine Lelay <catherine.lelay@inria.fr>" "Guillaume Melquiond <guillaume.melquiond@inria.fr>" ]

--- a/released/packages/coq-coquelicot/coq-coquelicot.2.1.2/opam
+++ b/released/packages/coq-coquelicot/coq-coquelicot.2.1.2/opam
@@ -11,7 +11,7 @@ build: [
 install: ["./remake" "install"]
 depends: [
   "coq" {>= "8.5" & < "8.7~"}
-  "coq-mathcomp-ssreflect" {>= "1.6"}
+  "coq-mathcomp-ssreflect" {>= "1.6" & < "1.16~"}
 ]
 tags: [ "keyword:real analysis" "keyword:topology" "keyword:filters" "keyword:metric spaces" "category:Mathematics/Real Calculus and Topology" ]
 authors: [ "Sylvie Boldo <sylvie.boldo@inria.fr>" "Catherine Lelay <catherine.lelay@inria.fr>" "Guillaume Melquiond <guillaume.melquiond@inria.fr>" ]

--- a/released/packages/coq-coquelicot/coq-coquelicot.3.0.2/opam
+++ b/released/packages/coq-coquelicot/coq-coquelicot.3.0.2/opam
@@ -11,7 +11,7 @@ build: [
 install: ["./remake" "install"]
 depends: [
   "coq" {>= "8.5" & < "8.10~"}
-  "coq-mathcomp-ssreflect" {>= "1.6"}
+  "coq-mathcomp-ssreflect" {>= "1.6" & < "1.16~"}
 ]
 tags: [ "keyword:real analysis" "keyword:topology" "keyword:filters" "keyword:metric spaces" "category:Mathematics/Real Calculus and Topology" ]
 authors: [ "Sylvie Boldo <sylvie.boldo@inria.fr>" "Catherine Lelay <catherine.lelay@inria.fr>" "Guillaume Melquiond <guillaume.melquiond@inria.fr>" ]

--- a/released/packages/coq-coquelicot/coq-coquelicot.3.0.3+8.11/opam
+++ b/released/packages/coq-coquelicot/coq-coquelicot.3.0.3+8.11/opam
@@ -12,7 +12,7 @@ build: [
 install: ["./remake" "install"]
 depends: [
   "coq" {= "8.11.0"}
-  "coq-mathcomp-ssreflect" {>= "1.6"}
+  "coq-mathcomp-ssreflect" {>= "1.6" & < "1.16~"}
   ("conf-g++" {build} | "conf-clang" {build})
   "conf-autoconf" {build}
 ]

--- a/released/packages/coq-coquelicot/coq-coquelicot.3.0.3/opam
+++ b/released/packages/coq-coquelicot/coq-coquelicot.3.0.3/opam
@@ -11,7 +11,7 @@ build: [
 install: ["./remake" "install"]
 depends: [
   "coq" {>= "8.8" & < "8.11"}
-  "coq-mathcomp-ssreflect" {>= "1.6"}
+  "coq-mathcomp-ssreflect" {>= "1.6" & < "1.16~"}
 ]
 tags: [ "keyword:real analysis" "keyword:topology" "keyword:filters" "keyword:metric spaces" "category:Mathematics/Real Calculus and Topology" "date:2019-07-22" ]
 authors: [ "Sylvie Boldo <sylvie.boldo@inria.fr>" "Catherine Lelay <catherine.lelay@inria.fr>" "Guillaume Melquiond <guillaume.melquiond@inria.fr>" ]

--- a/released/packages/coq-coquelicot/coq-coquelicot.3.3.1/opam
+++ b/released/packages/coq-coquelicot/coq-coquelicot.3.3.1/opam
@@ -12,7 +12,7 @@ build: [
 install: ["./remake" "install"]
 depends: [
   "coq" {>= "8.12" & < "8.19~"}
-  "coq-mathcomp-ssreflect" {>= "1.6"}
+  "coq-mathcomp-ssreflect" {>= "1.6" & < "1.16~"}
   "conf-autoconf" {build & dev}
   ("conf-g++" {build} | "conf-clang" {build})
 ]

--- a/released/packages/coq-coquelicot/coq-coquelicot.3.4.0/opam
+++ b/released/packages/coq-coquelicot/coq-coquelicot.3.4.0/opam
@@ -12,7 +12,7 @@ build: [
 install: ["./remake" "install"]
 depends: [
   "coq" {>= "8.12" & < "8.19~"}
-  "coq-mathcomp-ssreflect" {>= "1.6"}
+  "coq-mathcomp-ssreflect" {>= "1.6" & < "2.1~"}
   "conf-autoconf" {build & dev}
   ("conf-g++" {build} | "conf-clang" {build})
 ]

--- a/released/packages/coq-coquelicot/coq-coquelicot.3.4.4/opam
+++ b/released/packages/coq-coquelicot/coq-coquelicot.3.4.4/opam
@@ -12,7 +12,7 @@ build: [
 install: ["./remake" "install"]
 depends: [
   ("coq" {>= "8.12" & < "8.17~"} | ("coq-core" & "coq-stdlib"))
-  "coq-mathcomp-ssreflect" {>= "1.6"}
+  "coq-mathcomp-ssreflect" {>= "1.6" & < "2.6~"}
   "conf-autoconf" {build & dev}
   ("conf-g++" {build} | "conf-clang" {build})
 ]


### PR DESCRIPTION
Latest release no longer compile on latest MathComp.

ci-skip: coq-coquelicot