### PR TITLE
core-dev: add coqide-server.dev compatibility wrapper for rocqide-server

### DIFF
--- a/core-dev/packages/coqide-server/coqide-server.dev/opam
+++ b/core-dev/packages/coqide-server/coqide-server.dev/opam
@@ -1,0 +1,12 @@
+opam-version: "2.0"
+synopsis: "Compatibility metapackage for the Coq XML protocol server after the Rocq renaming"
+maintainer: ["The Rocq development team <coqdev@inria.fr>"]
+authors: ["The Rocq development team, INRIA, CNRS, and contributors"]
+license: "LGPL-2.1-only"
+homepage: "https://rocq-prover.org/"
+doc: "https://rocq-prover.org/docs"
+bug-reports: "https://github.com/rocq-prover/rocq/issues"
+depends: [
+  "rocqide-server" {= version}
+]
+dev-repo: "git+https://github.com/rocq-prover/rocq.git"


### PR DESCRIPTION
On rocq master the IDE XML-protocol server package was renamed from `coqide-server` to `rocqide-server`. As a result there is no master-tracking `coqide-server` recipe left in `core-dev`: the newest `coqide-server` recipes are version-pinned to release branches (`coqide-server.9.3.dev` -> `#v9.3`, and older), which still build because those branches still define `coqide-server.opam`.

Root `.opam` files in the rocq tree:

- master: `rocqide-server.opam`, `rocqide.opam` (no `coqide-server.opam`)
- v9.3: `coqide-server.opam`

A build-style recipe tracking master (`dune build -p coqide-server` against `git+https://github.com/rocq-prover/rocq.git#master`) therefore fails with:

    Error: I don't know about package coqide-server (passed through --only-packages)

This PR adds `core-dev/packages/coqide-server/coqide-server.dev/opam` as a thin compatibility metapackage depending on `rocqide-server {= version}`, so `coqide-server` stays installable on dev switches and pulls in the renamed package. It mirrors the existing renaming wrappers `coq.dev` and `coq-stdlib.dev` (the latter converted in #3838).

New file:

    opam-version: "2.0"
    synopsis: "Compatibility metapackage for the Coq XML protocol server after the Rocq renaming"
    maintainer: ["The Rocq development team <coqdev@inria.fr>"]
    authors: ["The Rocq development team, INRIA, CNRS, and contributors"]
    license: "LGPL-2.1-only"
    homepage: "https://rocq-prover.org/"
    doc: "https://rocq-prover.org/docs"
    bug-reports: "https://github.com/rocq-prover/rocq/issues"
    depends: [
      "rocqide-server" {= version}
    ]
    dev-repo: "git+https://github.com/rocq-prover/rocq.git"

`opam lint` passes on the new file.

Opened autonomously by Claude (Opus 5) on behalf of Jason Gross (jason@theorem.dev).
