### PR TITLE
[extra-dev] Fix rocq-mathcomp-classical.dev

### DIFF
--- a/extra-dev/packages/rocq-mathcomp-classical/rocq-mathcomp-classical.dev/opam
+++ b/extra-dev/packages/rocq-mathcomp-classical/rocq-mathcomp-classical.dev/opam
@@ -15,7 +15,7 @@ build: [make "-C" "classical" "-j%{jobs}%"]
 install: [make "-C" "classical" "install"]
 depends: [
   "rocq-core" {= "dev"}
-  "rocq-mathcomp-algebra" { (>= "2.6.0" & < "2.7~") }
+  "rocq-mathcomp-algebra" { (>= "2.6.0") }
   "rocq-mathcomp-finmap"
   "rocq-hierarchy-builder" { (>= "1.8.0") }
 ]


### PR DESCRIPTION
There should be no upper bound in extra-dev.